### PR TITLE
feat: add canonical multi-agent conversion layer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,12 +23,19 @@ Centralized exception definitions. `SessionParseError` for all parse failures.
 Core parser layer with ecosystem extensibility.
 
 - `base.py` — `TrajectoryParser` ABC defining the interface: `parse_file()`, `extract_metadata()`, `calculate_statistics()`, `find_session_files()`, `parse_session()`
+- `canonical.py` — Canonical conversion middle layer:
+  - `CanonicalEvent` / `CanonicalSession` agent-neutral models
+  - `TrajectoryEventAdapter` contract (`to_canonical_event()` and `canonical_to_message()`)
+  - adapter registry (`register_adapter()`, `get_adapter()`, `list_adapters()`)
+  - conversion helpers: `parse_jsonl_to_canonical()` and `canonical_to_messages()`
 - `claude_code.py` — `ClaudeCodeParser` class implementing the ABC. Contains all parsing logic as module-level functions (single-pass loop, tool tracking, time attribution, bash breakdown, compact event extraction)
 - `registry.py` — Parser registry with `register_parser()` / `get_parser(ecosystem)` factory. Auto-registers `ClaudeCodeParser` for `"claude_code"` ecosystem
 - `session_parser.py` — Backward-compatibility shim re-exporting from `claude_code.py`
 - `__init__.py` — Public API: `parse_session_file()`, `parse_session_directory()`, `SessionParseError`, `ClaudeCodeParser`
 
 **Parser algorithm** (in `claude_code.py`):
+0. **Canonical conversion** — each source JSONL line is normalized through ecosystem adapter:
+   `source json -> CanonicalEvent -> MessageRecord`
 1. **Message counting** — user, assistant, system counts
 2. **Token accumulation** — input, output, cache read, cache creation
 3. **Tool tracking** — `tool_use_map` maps `tool_use_id → (tool_name, timestamp)`. When a matching `tool_result` arrives, latency = `result_ts - use_ts`.
@@ -127,6 +134,7 @@ Pytest test suite. Fixtures in `conftest.py` (composable). Test data in `tests/f
 ## Invariants
 
 - Parser is single-pass: every message is visited exactly once in chronological order
+- All ecosystems parse through the canonical adapter contract before entering analytics logic
 - Time percentages (model/tool/user) are computed over active time only; inactive time is separate
 - CLI data output goes to stdout, status/error messages to stderr
 - All Python functions must have type annotations (`mypy --strict`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Canonical `agent-vis` CLI entry point in `pyproject.toml`, while preserving `claude-vis` for backward compatibility.
 - Installation/uninstallation scripts now manage both global commands (`agent-vis` canonical, `claude-vis` legacy alias).
 - Namespace compatibility regression tests to ensure canonical and legacy imports expose equivalent symbols.
+- Canonical parser middle layer (`claude_vis.parsers.canonical`) with adapter contract (`TrajectoryEventAdapter`), neutral event models (`CanonicalEvent` / `CanonicalSession`), and ecosystem adapter registry.
+- Canonical conversion contract tests covering registry extension, source-to-canonical normalization, and canonical-to-message compatibility behavior.
 
 ### Changed
 
 - API branding and metadata text to ecosystem-neutral naming (`Agent Trajectory Visualizer API`) instead of Claude-only wording.
 - CLI user-facing branding and examples now prefer `agent-vis` as canonical command.
 - README (EN/CN) now includes explicit migration notes and deprecation path for `claude_vis` -> `agent_vis`.
+- Claude parser ingestion path now uses the canonical adapter pipeline (`JSONL -> CanonicalEvent -> MessageRecord`) without changing downstream statistics logic.
 
 ## [0.6.0] - 2026-02-26
 

--- a/agent_vis/parsers/canonical.py
+++ b/agent_vis/parsers/canonical.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for canonical namespace."""
+
+from claude_vis.parsers.canonical import *  # noqa: F401,F403

--- a/claude_vis/parsers/__init__.py
+++ b/claude_vis/parsers/__init__.py
@@ -2,6 +2,14 @@
 
 from claude_vis.exceptions import SessionParseError
 from claude_vis.parsers.base import TrajectoryParser
+from claude_vis.parsers.canonical import (
+    CanonicalEvent,
+    CanonicalSession,
+    TrajectoryEventAdapter,
+    get_adapter,
+    list_adapters,
+    register_adapter,
+)
 from claude_vis.parsers.claude_code import (
     ClaudeCodeParser,
     parse_session_directory,
@@ -10,12 +18,18 @@ from claude_vis.parsers.claude_code import (
 from claude_vis.parsers.registry import get_parser, list_ecosystems, register_parser
 
 __all__ = [
+    "CanonicalEvent",
+    "CanonicalSession",
     "ClaudeCodeParser",
     "SessionParseError",
     "TrajectoryParser",
+    "TrajectoryEventAdapter",
+    "get_adapter",
+    "list_adapters",
     "get_parser",
     "list_ecosystems",
     "parse_session_directory",
     "parse_session_file",
+    "register_adapter",
     "register_parser",
 ]

--- a/claude_vis/parsers/canonical.py
+++ b/claude_vis/parsers/canonical.py
@@ -1,0 +1,157 @@
+"""Canonical multi-agent conversion layer for trajectory ingestion.
+
+This module defines an adapter contract and an agent-neutral canonical event
+model used to normalize source JSONL records before converting them into the
+internal ``MessageRecord`` model.
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError
+
+from claude_vis.exceptions import SessionParseError
+from claude_vis.models import MessageRecord
+
+
+class CanonicalEvent(BaseModel):
+    """Agent-neutral normalized event representation."""
+
+    ecosystem: str
+    source_path: str
+    line_number: int = Field(ge=1)
+    event_kind: str = "message"
+    timestamp: str | None = None
+    actor: str | None = None
+    payload: dict[str, Any]
+
+
+class CanonicalSession(BaseModel):
+    """Canonical event stream for a source trajectory file."""
+
+    ecosystem: str
+    source_path: str
+    events: list[CanonicalEvent]
+
+
+class TrajectoryEventAdapter(ABC):
+    """Adapter contract: source JSON record <-> canonical event/message."""
+
+    @property
+    @abstractmethod
+    def ecosystem_name(self) -> str:
+        """Stable ecosystem identifier (for example, ``claude_code``)."""
+        ...
+
+    @abstractmethod
+    def to_canonical_event(
+        self, raw_event: dict[str, Any], *, source_path: Path, line_number: int
+    ) -> CanonicalEvent | None:
+        """Convert one source JSON object into a canonical event."""
+        ...
+
+    @abstractmethod
+    def canonical_to_message(self, event: CanonicalEvent) -> MessageRecord | None:
+        """Convert canonical event into internal message model."""
+        ...
+
+
+_adapter_registry: dict[str, type[TrajectoryEventAdapter]] = {}
+
+
+def register_adapter(
+    adapter_cls: type[TrajectoryEventAdapter],
+) -> type[TrajectoryEventAdapter]:
+    """Register an adapter class by ecosystem name."""
+    ecosystem_name = adapter_cls.__dict__.get("ecosystem_name")
+    if ecosystem_name is None or isinstance(ecosystem_name, property):
+        instance = object.__new__(adapter_cls)
+        ecosystem_name = instance.ecosystem_name  # type: ignore[attr-defined]
+
+    if not isinstance(ecosystem_name, str):
+        raise TypeError(
+            "Adapter ecosystem_name must be a string or property returning string"
+        )
+
+    _adapter_registry[ecosystem_name] = adapter_cls
+    return adapter_cls
+
+
+def get_adapter(ecosystem: str) -> TrajectoryEventAdapter:
+    """Get an adapter instance for a specific ecosystem."""
+    if ecosystem not in _adapter_registry:
+        available = ", ".join(sorted(_adapter_registry.keys())) or "(none)"
+        raise KeyError(
+            f"No canonical adapter registered for ecosystem '{ecosystem}'. "
+            f"Available: {available}"
+        )
+    return _adapter_registry[ecosystem]()
+
+
+def list_adapters() -> list[str]:
+    """List registered ecosystem adapter names."""
+    return sorted(_adapter_registry.keys())
+
+
+def parse_jsonl_to_canonical(
+    file_path: Path, adapter: TrajectoryEventAdapter
+) -> CanonicalSession:
+    """Parse JSONL file into canonical events via adapter conversion."""
+    events: list[CanonicalEvent] = []
+
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            for line_num, line in enumerate(f, 1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+
+                try:
+                    data = json.loads(stripped)
+                except json.JSONDecodeError as e:
+                    raise SessionParseError(
+                        f"Invalid JSON at {file_path}:{line_num}: {e}"
+                    ) from e
+
+                if not isinstance(data, dict):
+                    continue
+
+                event = adapter.to_canonical_event(
+                    data,
+                    source_path=file_path,
+                    line_number=line_num,
+                )
+                if event is not None:
+                    events.append(event)
+    except FileNotFoundError as e:
+        raise SessionParseError(f"Session file not found: {file_path}") from e
+    except OSError as e:
+        raise SessionParseError(f"Error reading file {file_path}: {e}") from e
+
+    return CanonicalSession(
+        ecosystem=adapter.ecosystem_name,
+        source_path=str(file_path),
+        events=events,
+    )
+
+
+def canonical_to_messages(
+    canonical_session: CanonicalSession, adapter: TrajectoryEventAdapter
+) -> list[MessageRecord]:
+    """Convert canonical events to internal messages, skipping invalid records."""
+    messages: list[MessageRecord] = []
+
+    for event in canonical_session.events:
+        try:
+            message = adapter.canonical_to_message(event)
+        except ValidationError:
+            continue
+
+        if message is not None:
+            messages.append(message)
+
+    return messages

--- a/claude_vis/parsers/claude_code.py
+++ b/claude_vis/parsers/claude_code.py
@@ -11,8 +11,7 @@ import re
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
-
-from pydantic import ValidationError
+from typing import Any
 
 from claude_vis.exceptions import SessionParseError
 from claude_vis.models import (
@@ -32,7 +31,14 @@ from claude_vis.models import (
     ToolGroupStatistics,
 )
 from claude_vis.parsers.base import TrajectoryParser
-
+from claude_vis.parsers.canonical import (
+    CanonicalEvent,
+    TrajectoryEventAdapter,
+    canonical_to_messages,
+    get_adapter,
+    parse_jsonl_to_canonical,
+    register_adapter,
+)
 
 # ---------------------------------------------------------------------------
 # Module-level helper functions (private)
@@ -201,6 +207,32 @@ def _has_tool_result_content(msg: MessageRecord) -> bool:
 # ---------------------------------------------------------------------------
 
 
+@register_adapter
+class ClaudeCodeEventAdapter(TrajectoryEventAdapter):
+    """Canonical conversion adapter for Claude Code source events."""
+
+    ecosystem_name = "claude_code"
+
+    def to_canonical_event(
+        self, raw_event: dict[str, Any], *, source_path: Path, line_number: int
+    ) -> CanonicalEvent | None:
+        timestamp = raw_event.get("timestamp")
+        event_type = raw_event.get("type")
+
+        return CanonicalEvent(
+            ecosystem=self.ecosystem_name,
+            source_path=str(source_path),
+            line_number=line_number,
+            event_kind=str(event_type or "message"),
+            timestamp=timestamp if isinstance(timestamp, str) else None,
+            actor=event_type if isinstance(event_type, str) else None,
+            payload=raw_event,
+        )
+
+    def canonical_to_message(self, event: CanonicalEvent) -> MessageRecord | None:
+        return MessageRecord(**event.payload)
+
+
 def parse_jsonl_file(file_path: Path) -> list[MessageRecord]:
     """
     Parse a JSONL session file into MessageRecord objects.
@@ -214,33 +246,9 @@ def parse_jsonl_file(file_path: Path) -> list[MessageRecord]:
     Raises:
         SessionParseError: If the file cannot be parsed
     """
-    messages: list[MessageRecord] = []
-
-    try:
-        with open(file_path, encoding="utf-8") as f:
-            for line_num, line in enumerate(f, 1):
-                line = line.strip()
-                if not line:
-                    continue
-
-                try:
-                    data = json.loads(line)
-                    message = MessageRecord(**data)
-                    messages.append(message)
-                except json.JSONDecodeError as e:
-                    raise SessionParseError(
-                        f"Invalid JSON at {file_path}:{line_num}: {e}"
-                    ) from e
-                except ValidationError:
-                    # Log validation error but continue parsing
-                    # Some fields may be optional or have unknown formats
-                    continue
-    except FileNotFoundError as e:
-        raise SessionParseError(f"Session file not found: {file_path}") from e
-    except OSError as e:
-        raise SessionParseError(f"Error reading file {file_path}: {e}") from e
-
-    return messages
+    adapter = get_adapter("claude_code")
+    canonical_session = parse_jsonl_to_canonical(file_path, adapter)
+    return canonical_to_messages(canonical_session, adapter)
 
 
 def extract_session_metadata(

--- a/tests/test_canonical_conversion.py
+++ b/tests/test_canonical_conversion.py
@@ -1,0 +1,94 @@
+"""Tests for canonical trajectory conversion layer and adapter contract."""
+
+import json
+from pathlib import Path
+
+from claude_vis.models import MessageRecord
+from claude_vis.parsers.canonical import (
+    CanonicalEvent,
+    TrajectoryEventAdapter,
+    canonical_to_messages,
+    get_adapter,
+    list_adapters,
+    parse_jsonl_to_canonical,
+    register_adapter,
+)
+from claude_vis.parsers.claude_code import parse_jsonl_file
+
+
+class TestCanonicalAdapterRegistry:
+    """Tests for canonical adapter registration and lookup."""
+
+    def test_builtin_claude_adapter_is_registered(self) -> None:
+        assert "claude_code" in list_adapters()
+        adapter = get_adapter("claude_code")
+        assert adapter.ecosystem_name == "claude_code"
+
+    def test_registry_supports_extension_without_core_changes(self) -> None:
+        class DummyAdapter(TrajectoryEventAdapter):
+            ecosystem_name = "dummy_ecosystem"
+
+            def to_canonical_event(
+                self, raw_event: dict[str, object], *, source_path: Path, line_number: int
+            ) -> None:
+                return None
+
+            def canonical_to_message(self, event: CanonicalEvent) -> MessageRecord | None:
+                return None
+
+        register_adapter(DummyAdapter)
+        adapter = get_adapter("dummy_ecosystem")
+        assert isinstance(adapter, DummyAdapter)
+
+
+class TestCanonicalConversionContract:
+    """Tests for source JSONL -> canonical event -> MessageRecord contract."""
+
+    def test_parse_jsonl_to_canonical_preserves_source_metadata(
+        self, sample_session_file: Path
+    ) -> None:
+        adapter = get_adapter("claude_code")
+        canonical_session = parse_jsonl_to_canonical(sample_session_file, adapter)
+
+        assert canonical_session.ecosystem == "claude_code"
+        assert canonical_session.source_path == str(sample_session_file)
+        assert len(canonical_session.events) == 4
+        assert canonical_session.events[0].line_number == 1
+        assert canonical_session.events[0].actor == "user"
+
+    def test_canonical_conversion_matches_current_claude_parser_output(
+        self, sample_session_file: Path
+    ) -> None:
+        adapter = get_adapter("claude_code")
+        canonical_session = parse_jsonl_to_canonical(sample_session_file, adapter)
+        converted_messages = canonical_to_messages(canonical_session, adapter)
+        parser_messages = parse_jsonl_file(sample_session_file)
+
+        assert [m.uuid for m in converted_messages] == [m.uuid for m in parser_messages]
+        assert [m.type for m in converted_messages] == [m.type for m in parser_messages]
+
+    def test_invalid_message_records_are_skipped_after_canonical_conversion(
+        self, temp_session_dir: Path
+    ) -> None:
+        file_path = temp_session_dir / "partial-valid.jsonl"
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "sessionId": "test",
+                        "uuid": "msg-1",
+                        "timestamp": "2026-02-03T13:15:17.231Z",
+                    }
+                )
+                + "\n"
+            )
+            f.write(json.dumps({"invalid": "data"}) + "\n")
+
+        adapter = get_adapter("claude_code")
+        canonical_session = parse_jsonl_to_canonical(file_path, adapter)
+        messages = canonical_to_messages(canonical_session, adapter)
+
+        assert len(canonical_session.events) == 2
+        assert len(messages) == 1
+        assert messages[0].uuid == "msg-1"


### PR DESCRIPTION
## Summary
- add canonical conversion middle layer: `claude_vis.parsers.canonical`
- define adapter contract (`TrajectoryEventAdapter`) and neutral event models (`CanonicalEvent`, `CanonicalSession`)
- add adapter registry (`register_adapter`, `get_adapter`, `list_adapters`)
- refactor Claude parser ingest path to `JSONL -> CanonicalEvent -> MessageRecord`
- export canonical adapter APIs from parser package and document architecture update
- add contract tests for canonical conversion and adapter extensibility

## Validation
- `uv run ruff check claude_vis/parsers/canonical.py claude_vis/parsers/claude_code.py claude_vis/parsers/__init__.py agent_vis/parsers/canonical.py tests/test_canonical_conversion.py --ignore E501`
- `uv run pytest tests/test_canonical_conversion.py tests/test_parser.py::TestParseJsonlFile tests/test_parser_integration.py::TestParserIntegrationWithSingleSession::test_parse_complete_session_file -q`

Refs #2
