### PR TITLE
feat: add tool error taxonomy timeline analytics (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Canonical conversion contract tests covering registry extension, source-to-canonical normalization, and canonical-to-message compatibility behavior.
 - New `CodexParser` with Codex rollout adapter for local files under `~/.codex/sessions/**/rollout-*.jsonl`.
 - Mixed-ecosystem API/session tests covering Codex fixture ingestion and `/api/sessions?ecosystem=` filtering.
+- Rule-based tool error taxonomy module (`claude_vis.parsers.error_taxonomy`) with versioned categories and `uncategorized` fallback for unmatched failures.
+- Session-level tool error timeline records (`timestamp`, `tool_name`, `category`, `matched_rule`, `preview`, `detail`) and per-category counters in `SessionStatistics`.
+- Regression fixtures/tests for taxonomy precision and fallback behavior (`tests/fixtures/error_taxonomy_examples.json`, `tests/test_error_taxonomy.py`).
+- Playwright smoke tests for tool error timeline rendering, expand/collapse details, and table scroll-container behavior on metrics dashboard.
 
 ### Changed
 
@@ -24,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - README (EN/CN) now includes explicit migration notes and deprecation path for `claude_vis` -> `agent_vis`.
 - Claude parser ingestion path now uses the canonical adapter pipeline (`JSONL -> CanonicalEvent -> MessageRecord`) without changing downstream statistics logic.
 - Session sync and service initialization now support mixed local roots (Claude + Codex), and session list responses now expose ecosystem metadata.
+- Statistics dashboard now includes taxonomy-aware tool error timeline table with category chips and expandable raw error detail rows.
 
 ## [0.6.0] - 2026-02-26
 

--- a/claude_vis/models.py
+++ b/claude_vis/models.py
@@ -259,6 +259,17 @@ class ToolCallStatistics(BaseModel):
     tool_group: str = ""
 
 
+class ToolErrorRecord(BaseModel):
+    """Detailed record for one failed tool execution."""
+
+    timestamp: str
+    tool_name: str
+    category: str
+    matched_rule: str | None = None
+    preview: str
+    detail: str
+
+
 class ToolGroupStatistics(BaseModel):
     """Aggregated statistics for a group of related tools (e.g., all MCP tools from one server)."""
 
@@ -371,6 +382,9 @@ class SessionStatistics(BaseModel):
     tool_calls: list[ToolCallStatistics] = Field(default_factory=list)
     tool_groups: list[ToolGroupStatistics] = Field(default_factory=list)
     total_tool_calls: int = 0
+    tool_error_records: list[ToolErrorRecord] = Field(default_factory=list)
+    tool_error_category_counts: dict[str, int] = Field(default_factory=dict)
+    error_taxonomy_version: str = "0.0.0"
 
     # Subagent statistics
     subagent_count: int = 0

--- a/claude_vis/parsers/claude_code.py
+++ b/claude_vis/parsers/claude_code.py
@@ -28,6 +28,7 @@ from claude_vis.models import (
     TimeBreakdown,
     TokenBreakdown,
     ToolCallStatistics,
+    ToolErrorRecord,
     ToolGroupStatistics,
 )
 from claude_vis.parsers.base import TrajectoryParser
@@ -38,6 +39,10 @@ from claude_vis.parsers.canonical import (
     get_adapter,
     parse_jsonl_to_canonical,
     register_adapter,
+)
+from claude_vis.parsers.error_taxonomy import (
+    ERROR_TAXONOMY_VERSION,
+    classify_tool_error,
 )
 
 # ---------------------------------------------------------------------------
@@ -200,6 +205,27 @@ def _has_tool_result_content(msg: MessageRecord) -> bool:
             if isinstance(block, dict) and block.get("type") == "tool_result":
                 return True
     return False
+
+
+def _extract_tool_result_text(content: str | list[dict[str, Any]] | Any) -> str:
+    """Normalize tool_result content into plain text for taxonomy matching."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        pieces: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    pieces.append(text)
+                else:
+                    pieces.append(json.dumps(block, ensure_ascii=False))
+            else:
+                pieces.append(str(block))
+        return "\n".join(pieces)
+    if content is None:
+        return ""
+    return str(content)
 
 
 # ---------------------------------------------------------------------------
@@ -386,6 +412,8 @@ def calculate_session_statistics(
     tool_use_map: dict[str, tuple[str, datetime]] = {}
     # Track subagent sessions by agent_id to deduplicate
     subagent_sessions_map: dict[str, str] = {}
+    tool_error_records: list[ToolErrorRecord] = []
+    tool_error_category_counts: Counter[str] = Counter()
 
     # Bash breakdown accumulators
     bash_command_counts: Counter[str] = Counter()
@@ -511,6 +539,28 @@ def calculate_session_statistics(
                                 if tool_name in tool_stats:
                                     if is_error:
                                         tool_stats[tool_name]["error"] += 1
+                                        error_text = _extract_tool_result_text(
+                                            content_block.get("content", "")
+                                        )
+                                        classification = classify_tool_error(error_text)
+                                        tool_error_category_counts[
+                                            classification.category
+                                        ] += 1
+                                        preview = (
+                                            error_text.strip().replace("\n", " ")[:160]
+                                            if error_text.strip()
+                                            else "(empty error output)"
+                                        )
+                                        tool_error_records.append(
+                                            ToolErrorRecord(
+                                                timestamp=timestamp.isoformat(),
+                                                tool_name=tool_name,
+                                                category=classification.category,
+                                                matched_rule=classification.rule_id,
+                                                preview=preview,
+                                                detail=error_text,
+                                            )
+                                        )
                                     else:
                                         tool_stats[tool_name]["success"] += 1
 
@@ -705,6 +755,9 @@ def calculate_session_statistics(
         tool_calls=tool_call_list,
         tool_groups=tool_group_list,
         total_tool_calls=sum(int(tool_stats[t]["count"]) for t in tool_stats),
+        tool_error_records=tool_error_records,
+        tool_error_category_counts=dict(tool_error_category_counts),
+        error_taxonomy_version=ERROR_TAXONOMY_VERSION,
         subagent_count=len(subagent_sessions_list),
         subagent_sessions=subagent_type_counts,
         session_duration_seconds=duration_seconds,

--- a/claude_vis/parsers/error_taxonomy.py
+++ b/claude_vis/parsers/error_taxonomy.py
@@ -1,0 +1,122 @@
+"""Rule-based tool error taxonomy for trajectory analytics."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+ERROR_TAXONOMY_VERSION = "1.0.0"
+UNCATEGORIZED_ERROR = "uncategorized"
+
+
+@dataclass(frozen=True)
+class ErrorTaxonomyRule:
+    """Single taxonomy rule entry."""
+
+    rule_id: str
+    category: str
+    label: str
+    pattern: str
+
+    def regex(self) -> re.Pattern[str]:
+        return re.compile(self.pattern, re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ErrorClassification:
+    """Taxonomy classification result."""
+
+    category: str
+    label: str
+    rule_id: str | None = None
+
+
+ERROR_TAXONOMY_RULES: tuple[ErrorTaxonomyRule, ...] = (
+    ErrorTaxonomyRule(
+        rule_id="permission_denied",
+        category="permission",
+        label="Permission Denied",
+        pattern=r"permission denied|operation not permitted|eacces|eperm",
+    ),
+    ErrorTaxonomyRule(
+        rule_id="command_not_found",
+        category="command",
+        label="Command Not Found",
+        pattern=r"command not found|is not recognized as an internal or external command",
+    ),
+    ErrorTaxonomyRule(
+        rule_id="file_not_found",
+        category="file_not_found",
+        label="File Not Found",
+        pattern=r"no such file|not found|enoent|cannot stat|does not exist",
+    ),
+    ErrorTaxonomyRule(
+        rule_id="timeout",
+        category="timeout",
+        label="Timeout",
+        pattern=r"timed out|timeout|deadline exceeded",
+    ),
+    ErrorTaxonomyRule(
+        rule_id="rate_limited",
+        category="rate_limit",
+        label="Rate Limited",
+        pattern=r"rate limit|too many requests|429",
+    ),
+    ErrorTaxonomyRule(
+        rule_id="network",
+        category="network",
+        label="Network Error",
+        pattern=r"connection refused|connection reset|network|enotfound|dns",
+    ),
+    ErrorTaxonomyRule(
+        rule_id="auth",
+        category="authentication",
+        label="Authentication Error",
+        pattern=r"unauthorized|forbidden|invalid api key|authentication failed",
+    ),
+    ErrorTaxonomyRule(
+        rule_id="patch_apply_failed",
+        category="patch",
+        label="Patch Apply Failed",
+        pattern=r"patch failed|hunk failed|apply_patch verification failed",
+    ),
+    ErrorTaxonomyRule(
+        rule_id="parse_error",
+        category="parsing",
+        label="Parsing Error",
+        pattern=r"jsondecodeerror|parse error|invalid json|yaml",
+    ),
+    ErrorTaxonomyRule(
+        rule_id="test_failure",
+        category="test_failure",
+        label="Test Failure",
+        pattern=r"assertionerror|\\bfailed\\b|traceback",
+    ),
+)
+
+_COMPILED_RULES = tuple((rule, rule.regex()) for rule in ERROR_TAXONOMY_RULES)
+
+
+def classify_tool_error(detail: str) -> ErrorClassification:
+    """Classify raw tool error text into a taxonomy category."""
+    normalized = detail.strip()
+    if not normalized:
+        return ErrorClassification(
+            category=UNCATEGORIZED_ERROR,
+            label="Uncategorized",
+            rule_id=None,
+        )
+
+    for rule, regex in _COMPILED_RULES:
+        if regex.search(normalized):
+            return ErrorClassification(
+                category=rule.category,
+                label=rule.label,
+                rule_id=rule.rule_id,
+            )
+
+    return ErrorClassification(
+        category=UNCATEGORIZED_ERROR,
+        label="Uncategorized",
+        rule_id=None,
+    )

--- a/frontend/src/components/StatisticsDashboard.css
+++ b/frontend/src/components/StatisticsDashboard.css
@@ -208,6 +208,85 @@
   font-weight: 600;
 }
 
+.error-taxonomy-note {
+  margin: 0 0 0.75rem 0;
+  color: #64748b;
+  font-size: 0.82rem;
+}
+
+.error-category-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 0.8rem;
+}
+
+.error-category-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid #dbe5ef;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  background: #f8fbff;
+  font-size: 0.78rem;
+}
+
+.error-category-name {
+  color: #334155;
+}
+
+.error-category-count {
+  color: #dc2626;
+  font-weight: 700;
+}
+
+.error-category-badge {
+  display: inline-block;
+  border-radius: 999px;
+  border: 1px solid #dbe5ef;
+  background: #f8fbff;
+  color: #334155;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.75rem;
+}
+
+.error-preview-cell {
+  max-width: 380px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #334155;
+}
+
+.error-expand-button {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #1d4ed8;
+  border-radius: 6px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.error-expand-button:hover {
+  background: #eff6ff;
+}
+
+.error-detail-row td {
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.error-detail-text {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: 'Courier New', monospace;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: #334155;
+}
+
 @media (max-width: 1200px) {
   .chart-card.wide {
     grid-column: span 1;

--- a/frontend/src/components/StatisticsDashboard.tsx
+++ b/frontend/src/components/StatisticsDashboard.tsx
@@ -8,7 +8,7 @@
  * - Resource Consumption
  */
 
-import { useEffect } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import {
   BarChart,
@@ -67,8 +67,17 @@ function formatDuration(seconds: number | null): string {
   return `${secs}s`;
 }
 
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
 export function StatisticsDashboard({ sessionId }: StatisticsDashboardProps) {
   const { data, isLoading, error: queryError } = useSessionStatisticsQuery(sessionId);
+  const [expandedErrors, setExpandedErrors] = useState<Record<string, boolean>>({});
 
   const statistics: SessionStatistics | null = data?.statistics || null;
   const loading = isLoading;
@@ -107,6 +116,17 @@ export function StatisticsDashboard({ sessionId }: StatisticsDashboardProps) {
   if (!statistics) {
     return null;
   }
+
+  const toolErrorRecords = statistics.tool_error_records || [];
+  const errorCategoryEntries = Object.entries(statistics.tool_error_category_counts || {})
+    .sort((a, b) => b[1] - a[1]);
+
+  const toggleErrorDetail = (key: string): void => {
+    setExpandedErrors((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  };
 
   const interactions = statistics.time_breakdown?.user_interaction_count || 0;
   const automationRatio = interactions > 0
@@ -384,6 +404,78 @@ export function StatisticsDashboard({ sessionId }: StatisticsDashboardProps) {
                       </td>
                     </tr>
                   ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {toolErrorRecords.length > 0 && (
+          <div className="table-card">
+            <h4 className="card-title">Tool Error Timeline</h4>
+            <p className="error-taxonomy-note">
+              Taxonomy v{statistics.error_taxonomy_version} · Unknown patterns are tracked as
+              {' '}
+              <code>uncategorized</code>
+            </p>
+
+            {errorCategoryEntries.length > 0 && (
+              <div className="error-category-row">
+                {errorCategoryEntries.map(([category, count]) => (
+                  <span key={category} className="error-category-chip">
+                    <span className="error-category-name">{category}</span>
+                    <span className="error-category-count">{formatNumber(count)}</span>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <div className="table-container">
+              <table className="stats-table error-timeline-table">
+                <thead>
+                  <tr>
+                    <th>Timestamp</th>
+                    <th>Tool</th>
+                    <th>Category</th>
+                    <th>Rule</th>
+                    <th>Preview</th>
+                    <th>Detail</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {toolErrorRecords.map((record, index) => {
+                    const rowKey = `${record.timestamp}-${record.tool_name}-${index}`;
+                    const isExpanded = expandedErrors[rowKey] === true;
+                    return (
+                      <Fragment key={rowKey}>
+                        <tr>
+                          <td>{formatTimestamp(record.timestamp)}</td>
+                          <td className="tool-name">{record.tool_name}</td>
+                          <td>
+                            <span className="error-category-badge">{record.category}</span>
+                          </td>
+                          <td>{record.matched_rule ?? '--'}</td>
+                          <td className="error-preview-cell">{record.preview}</td>
+                          <td>
+                            <button
+                              type="button"
+                              className="error-expand-button"
+                              onClick={() => toggleErrorDetail(rowKey)}
+                            >
+                              {isExpanded ? 'Collapse' : 'Expand'}
+                            </button>
+                          </td>
+                        </tr>
+                        isExpanded ? (
+                          <tr className="error-detail-row">
+                            <td colSpan={6}>
+                              <pre className="error-detail-text">{record.detail}</pre>
+                            </td>
+                          </tr>
+                        ) : null
+                      </Fragment>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -5,6 +5,7 @@
 
 export interface SessionSummary {
   session_id: string;
+  ecosystem: string;
   project_path: string;
   created_at: string;
   updated_at: string | null;
@@ -233,6 +234,15 @@ export interface ToolGroupStatistics {
   tools: string[];
 }
 
+export interface ToolErrorRecord {
+  timestamp: string;
+  tool_name: string;
+  category: string;
+  matched_rule: string | null;
+  preview: string;
+  detail: string;
+}
+
 export interface CompactEvent {
   timestamp: string;
   trigger: string;
@@ -269,6 +279,9 @@ export interface SessionStatistics {
   tool_calls: ToolCallStatistics[];
   tool_groups: ToolGroupStatistics[];
   total_tool_calls: number;
+  tool_error_records: ToolErrorRecord[];
+  tool_error_category_counts: Record<string, number>;
+  error_taxonomy_version: string;
   subagent_count: number;
   subagent_sessions: Record<string, number>;
   session_duration_seconds: number | null;

--- a/frontend/tests/fixtures/mockData.ts
+++ b/frontend/tests/fixtures/mockData.ts
@@ -13,6 +13,7 @@ export const mockSessionList: SessionListResponse = {
   sessions: [
     {
       session_id: 'test-session-001',
+      ecosystem: 'claude_code',
       project_path: '/home/user/project',
       created_at: '2024-02-01T10:00:00Z',
       updated_at: '2024-02-01T11:30:00Z',
@@ -20,9 +21,14 @@ export const mockSessionList: SessionListResponse = {
       total_tokens: 15000,
       git_branch: 'main',
       version: '1.0.0',
+      parsed_at: null,
+      duration_seconds: 5400,
+      bottleneck: 'Model',
+      automation_ratio: 2.8,
     },
     {
       session_id: 'test-session-002',
+      ecosystem: 'claude_code',
       project_path: '/home/user/project',
       created_at: '2024-02-02T14:00:00Z',
       updated_at: '2024-02-02T15:45:00Z',
@@ -30,9 +36,16 @@ export const mockSessionList: SessionListResponse = {
       total_tokens: 25000,
       git_branch: 'feature/new-feature',
       version: '1.0.0',
+      parsed_at: null,
+      duration_seconds: 6300,
+      bottleneck: 'Tool',
+      automation_ratio: 3.2,
     },
   ],
   count: 2,
+  page: 1,
+  page_size: 200,
+  total_pages: 1,
 };
 
 const mockMessages: MessageRecord[] = [
@@ -174,6 +187,9 @@ export const mockSessionStatistics: SessionStatisticsResponse = {
         total_tokens: 3000,
         success_count: 14,
         error_count: 1,
+        total_latency_seconds: 18,
+        avg_latency_seconds: 1.2,
+        tool_group: 'Read',
       },
       {
         tool_name: 'Edit',
@@ -181,6 +197,9 @@ export const mockSessionStatistics: SessionStatisticsResponse = {
         total_tokens: 2000,
         success_count: 8,
         error_count: 0,
+        total_latency_seconds: 20,
+        avg_latency_seconds: 2.5,
+        tool_group: 'Edit',
       },
       {
         tool_name: 'Bash',
@@ -188,9 +207,16 @@ export const mockSessionStatistics: SessionStatisticsResponse = {
         total_tokens: 1500,
         success_count: 4,
         error_count: 1,
+        total_latency_seconds: 35,
+        avg_latency_seconds: 7,
+        tool_group: 'Bash',
       },
     ],
+    tool_groups: [],
     total_tool_calls: 28,
+    tool_error_records: [],
+    tool_error_category_counts: {},
+    error_taxonomy_version: '1.0.0',
     subagent_count: 2,
     subagent_sessions: {
       Explore: 1,

--- a/frontend/tests/statistics-dashboard.spec.ts
+++ b/frontend/tests/statistics-dashboard.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * E2E tests for StatisticsDashboard rendering and interaction.
+ */
+
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { setupMockApi } from './fixtures/mockServer';
+import { mockSessionStatistics } from './fixtures/mockData';
+
+async function openStatisticsTab(page: Page): Promise<void> {
+  await page.waitForSelector('.tab-button', { timeout: 10000 });
+  await page.getByRole('button', { name: 'Statistics' }).click();
+  await page.waitForSelector('.statistics-dashboard', { timeout: 10000 });
+}
+
+test.describe('@smoke Statistics Dashboard - Tool Errors', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMockApi(page);
+
+    await page.route(/\/api\/sessions\/test-session-(001|002)\/statistics$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSessionStatistics,
+          statistics: {
+            ...mockSessionStatistics.statistics,
+            tool_error_records: [
+              {
+                timestamp: '2026-02-26T08:30:00Z',
+                tool_name: 'Edit',
+                category: 'file_not_found',
+                matched_rule: 'file_not_found',
+                preview: "Error: string not found in '/tmp/app.ts'",
+                detail: "Error: string not found in '/tmp/app.ts'",
+              },
+              {
+                timestamp: '2026-02-26T08:31:00Z',
+                tool_name: 'Bash',
+                category: 'uncategorized',
+                matched_rule: null,
+                preview: 'custom runtime error from unknown wrapper',
+                detail: 'custom runtime error from unknown wrapper',
+              },
+            ],
+            tool_error_category_counts: {
+              file_not_found: 1,
+              uncategorized: 1,
+            },
+            error_taxonomy_version: '1.0.0',
+          },
+        }),
+      });
+    });
+  });
+
+  test('should render error timeline with expandable details', async ({ page }) => {
+    await page.goto('/');
+    await openStatisticsTab(page);
+    await expect(page.locator('.dashboard-title')).toHaveText('Session Metrics');
+    await expect(page.locator('.card-title', { hasText: 'Tool Error Timeline' })).toBeVisible();
+
+    const categoryChips = page.locator('.error-category-chip');
+    await expect(categoryChips).toHaveCount(2);
+    await expect(categoryChips.first()).toContainText('file_not_found');
+
+    const mainRows = page.locator('.error-timeline-table tbody tr:not(.error-detail-row)');
+    await expect(mainRows).toHaveCount(2);
+
+    const firstExpand = page.locator('.error-expand-button').first();
+    await expect(firstExpand).toHaveText('Expand');
+    await firstExpand.click();
+
+    const detailRow = page.locator('.error-detail-row').first();
+    await expect(detailRow).toBeVisible();
+    await expect(detailRow).toContainText("string not found in '/tmp/app.ts'");
+
+    await firstExpand.click();
+    await expect(firstExpand).toHaveText('Expand');
+  });
+
+  test('should expose horizontal scroll container for dense error tables', async ({ page }) => {
+    await page.setViewportSize({ width: 960, height: 720 });
+    await page.goto('/');
+    await openStatisticsTab(page);
+    await page.waitForSelector('.error-timeline-table', { timeout: 10000 });
+
+    const overflowX = await page.locator('.error-timeline-table').evaluate((table) =>
+      window.getComputedStyle(table.parentElement as HTMLElement).overflowX
+    );
+    expect(['auto', 'scroll']).toContain(overflowX);
+  });
+});

--- a/tests/fixtures/error_taxonomy_examples.json
+++ b/tests/fixtures/error_taxonomy_examples.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "perm-001",
+    "detail": "Permission denied while opening /root/.ssh/config",
+    "expected_category": "permission",
+    "expected_rule_id": "permission_denied"
+  },
+  {
+    "id": "file-001",
+    "detail": "ENOENT: no such file or directory, open '/tmp/missing.txt'",
+    "expected_category": "file_not_found",
+    "expected_rule_id": "file_not_found"
+  },
+  {
+    "id": "cmd-001",
+    "detail": "bash: rgx: command not found",
+    "expected_category": "command",
+    "expected_rule_id": "command_not_found"
+  },
+  {
+    "id": "timeout-001",
+    "detail": "operation timed out after 30000ms",
+    "expected_category": "timeout",
+    "expected_rule_id": "timeout"
+  },
+  {
+    "id": "rate-001",
+    "detail": "HTTP 429 Too Many Requests",
+    "expected_category": "rate_limit",
+    "expected_rule_id": "rate_limited"
+  },
+  {
+    "id": "network-001",
+    "detail": "dial tcp 127.0.0.1:443: connect: connection refused",
+    "expected_category": "network",
+    "expected_rule_id": "network"
+  },
+  {
+    "id": "auth-001",
+    "detail": "authentication failed: invalid api key",
+    "expected_category": "authentication",
+    "expected_rule_id": "auth"
+  },
+  {
+    "id": "patch-001",
+    "detail": "apply_patch verification failed: patch failed at line 42",
+    "expected_category": "patch",
+    "expected_rule_id": "patch_apply_failed"
+  },
+  {
+    "id": "parse-001",
+    "detail": "JSONDecodeError: invalid JSON payload",
+    "expected_category": "parsing",
+    "expected_rule_id": "parse_error"
+  },
+  {
+    "id": "test-001",
+    "detail": "AssertionError: expected 2 but got 1",
+    "expected_category": "test_failure",
+    "expected_rule_id": "test_failure"
+  },
+  {
+    "id": "unknown-001",
+    "detail": "unexpected widget explosion in custom plugin",
+    "expected_category": "uncategorized",
+    "expected_rule_id": null
+  },
+  {
+    "id": "unknown-002",
+    "detail": "",
+    "expected_category": "uncategorized",
+    "expected_rule_id": null
+  }
+]

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -259,6 +259,12 @@ class TestSessionStatisticsAPI:
             assert "total_tool_calls" in stats
             assert "tool_calls" in stats
             assert isinstance(stats["tool_calls"], list)
+            assert "tool_error_records" in stats
+            assert isinstance(stats["tool_error_records"], list)
+            assert "tool_error_category_counts" in stats
+            assert isinstance(stats["tool_error_category_counts"], dict)
+            assert "error_taxonomy_version" in stats
+            assert isinstance(stats["error_taxonomy_version"], str)
 
     def test_get_statistics_not_found(self, test_client: TestClient) -> None:
         """Test getting statistics for non-existent session returns 404."""

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,0 +1,61 @@
+"""Regression tests for rule-based tool error taxonomy."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_vis.parsers.error_taxonomy import (
+    ERROR_TAXONOMY_VERSION,
+    UNCATEGORIZED_ERROR,
+    classify_tool_error,
+)
+
+
+def _load_examples() -> list[dict[str, str | None]]:
+    fixture_path = Path(__file__).parent / "fixtures" / "error_taxonomy_examples.json"
+    with fixture_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_error_taxonomy_examples_precision() -> None:
+    """Validate taxonomy precision against curated examples."""
+    examples = _load_examples()
+    total = len(examples)
+    matched = 0
+    misses: list[str] = []
+
+    for sample in examples:
+        result = classify_tool_error(str(sample["detail"]))
+        expected_category = sample["expected_category"]
+        expected_rule_id = sample["expected_rule_id"]
+        if result.category == expected_category and result.rule_id == expected_rule_id:
+            matched += 1
+        else:
+            misses.append(
+                f'{sample["id"]}: expected({expected_category}, {expected_rule_id}) '
+                f'got({result.category}, {result.rule_id})'
+            )
+
+    precision = matched / total if total else 0.0
+    note = (
+        f"taxonomy precision={precision:.3f} ({matched}/{total}); "
+        f"misses={'; '.join(misses) if misses else 'none'}"
+    )
+    # Precision note: this fixture set covers the currently supported rule families
+    # and baseline fallback behavior; update examples whenever taxonomy rules evolve.
+    assert precision >= 0.95, note
+
+
+def test_error_taxonomy_version_semver_shape() -> None:
+    """Version marker should be explicitly versioned for analytics compatibility."""
+    segments = ERROR_TAXONOMY_VERSION.split(".")
+    assert len(segments) == 3
+    assert all(segment.isdigit() for segment in segments)
+
+
+def test_error_taxonomy_uncategorized_fallback() -> None:
+    """Unknown tool errors should be bucketed to uncategorized."""
+    result = classify_tool_error("nonstandard failure mode with bespoke output")
+    assert result.category == UNCATEGORIZED_ERROR
+    assert result.rule_id is None

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -12,6 +12,10 @@ import pytest
 
 from claude_vis.models import SessionStatistics, ToolCallStatistics
 from claude_vis.parsers import parse_session_file
+from claude_vis.parsers.error_taxonomy import (
+    ERROR_TAXONOMY_VERSION,
+    UNCATEGORIZED_ERROR,
+)
 from claude_vis.parsers.session_parser import (
     calculate_session_statistics,
     extract_subagent_sessions,
@@ -339,6 +343,81 @@ class TestCalculateSessionStatistics:
         edit_tool = next((tc for tc in stats.tool_calls if tc.tool_name == "Edit"), None)
         assert edit_tool is not None
         assert edit_tool.total_tokens == 180
+
+    def test_tool_error_records_are_categorized(
+        self, temp_session_dir: Path, sample_messages_with_tools: list[dict[str, object]]
+    ) -> None:
+        """Failed tool results should produce detailed taxonomy records."""
+        file_path = temp_session_dir / "test.jsonl"
+        with open(file_path, "w", encoding="utf-8") as f:
+            for data in sample_messages_with_tools:
+                f.write(json.dumps(data) + "\n")
+
+        messages = parse_jsonl_file(file_path)
+        stats = calculate_session_statistics(messages)
+
+        assert stats.error_taxonomy_version == ERROR_TAXONOMY_VERSION
+        assert len(stats.tool_error_records) == 1
+        first_error = stats.tool_error_records[0]
+        assert first_error.tool_name == "Edit"
+        assert first_error.category == "file_not_found"
+        assert first_error.matched_rule == "file_not_found"
+        assert "string not found" in first_error.detail
+        assert stats.tool_error_category_counts == {"file_not_found": 1}
+
+    def test_tool_error_records_fallback_to_uncategorized(
+        self, temp_session_dir: Path
+    ) -> None:
+        """Unknown error text should map to uncategorized bucket."""
+        file_path = temp_session_dir / "unknown-error.jsonl"
+        unknown_error_messages = [
+            {
+                "type": "assistant",
+                "sessionId": "session-unknown-error",
+                "uuid": "msg-1",
+                "timestamp": "2026-02-03T13:15:17.231Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tool-custom-1",
+                            "name": "CustomTool",
+                            "input": {"query": "data"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "sessionId": "session-unknown-error",
+                "uuid": "msg-2",
+                "timestamp": "2026-02-03T13:15:18.231Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool-custom-1",
+                            "content": "mysterious widget meltdown in subsystem omega",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            },
+        ]
+
+        with open(file_path, "w", encoding="utf-8") as f:
+            for data in unknown_error_messages:
+                f.write(json.dumps(data) + "\n")
+
+        messages = parse_jsonl_file(file_path)
+        stats = calculate_session_statistics(messages)
+
+        assert len(stats.tool_error_records) == 1
+        assert stats.tool_error_records[0].category == UNCATEGORIZED_ERROR
+        assert stats.tool_error_records[0].matched_rule is None
+        assert stats.tool_error_category_counts == {UNCATEGORIZED_ERROR: 1}
 
     def test_session_duration(
         self, temp_session_dir: Path, sample_messages_with_tools: list[dict[str, object]]


### PR DESCRIPTION
## Summary\n- add versioned rule-based tool error taxonomy with uncategorized fallback\n- emit per-error timeline records and category counts in session statistics\n- render taxonomy-aware Tool Error Timeline UI with expandable details\n- add backend taxonomy regression fixtures/tests and frontend smoke e2e coverage\n\n## Validation\n- uv run ruff check claude_vis/parsers/error_taxonomy.py tests/test_error_taxonomy.py tests/test_statistics.py tests/test_api_integration.py\n- uv run pytest tests/test_error_taxonomy.py tests/test_statistics.py tests/test_api_integration.py::TestSessionStatisticsAPI::test_statistics_tool_call_data -q\n- npm --prefix frontend run lint -- src/components/StatisticsDashboard.tsx tests/statistics-dashboard.spec.ts\n- npm --prefix frontend run test:e2e -- tests/statistics-dashboard.spec.ts --project=chromium\n- npm --prefix frontend run type-check