### PR TITLE
feat: add compact session table browsing mode (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Session-level tool error timeline records (`timestamp`, `tool_name`, `category`, `matched_rule`, `preview`, `detail`) and per-category counters in `SessionStatistics`.
 - Regression fixtures/tests for taxonomy precision and fallback behavior (`tests/fixtures/error_taxonomy_examples.json`, `tests/test_error_taxonomy.py`).
 - Playwright smoke tests for tool error timeline rendering, expand/collapse details, and table scroll-container behavior on metrics dashboard.
+- Compact session table mode in session browser with row-based selection, ecosystem column, and dense cross-session scan layout.
 
 ### Changed
 
@@ -29,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Claude parser ingestion path now uses the canonical adapter pipeline (`JSONL -> CanonicalEvent -> MessageRecord`) without changing downstream statistics logic.
 - Session sync and service initialization now support mixed local roots (Claude + Codex), and session list responses now expose ecosystem metadata.
 - Statistics dashboard now includes taxonomy-aware tool error timeline table with category chips and expandable raw error detail rows.
+- Session browser supports explicit card/table mode toggle while reusing existing search/sort/date filters and selection behavior in both views.
 
 ## [0.6.0] - 2026-02-26
 

--- a/frontend/src/components/SessionBrowser.css
+++ b/frontend/src/components/SessionBrowser.css
@@ -56,6 +56,41 @@
   color: #666;
 }
 
+.session-browser-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.session-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.session-view-toggle__button {
+  border: none;
+  background: #ffffff;
+  color: #334155;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+}
+
+.session-view-toggle__button.active {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.session-view-toggle__button:not(.active):hover {
+  background: #eff6ff;
+}
+
 /* Compare button */
 .compare-button {
   padding: 0.5rem 0.9rem;
@@ -221,6 +256,11 @@
     width: 100%;
     text-align: center;
     font-size: 0.75rem;
+  }
+
+  .session-browser-meta {
+    width: 100%;
+    justify-content: center;
   }
 }
 

--- a/frontend/src/components/SessionBrowser.tsx
+++ b/frontend/src/components/SessionBrowser.tsx
@@ -31,6 +31,8 @@ interface SessionBrowserProps {
   comparisonSessionId?: string | null;
 }
 
+type SessionViewMode = 'cards' | 'table';
+
 const EMPTY_SESSIONS: SessionSummary[] = [];
 
 function shortId(sessionId: string | null | undefined): string {
@@ -65,6 +67,7 @@ export function SessionBrowser({
   );
 
   const [isPickingComparison, setIsPickingComparison] = useState(false);
+  const [viewMode, setViewMode] = useState<SessionViewMode>('cards');
 
   // Filter and sort state
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -74,7 +77,7 @@ export function SessionBrowser({
   );
 
   const sessions: SessionSummary[] = data?.sessions ?? EMPTY_SESSIONS;
-  const loading = isLoading;
+  const loading = isLoading && !data;
   const error = queryError?.message || null;
 
   const initRef = useRef(false);
@@ -251,12 +254,33 @@ export function SessionBrowser({
             sessions={filteredAndSortedSessions}
             selectedId={activeSessionId}
             onSelect={handleSessionSelect}
+            viewMode={viewMode}
           />
         </div>
 
         <div className="session-browser-actions">
-          <div className="session-count">
-            {filteredAndSortedSessions.length} of {sessions.length} sessions
+          <div className="session-browser-meta">
+            <div className="session-view-toggle" role="group" aria-label="Session view mode">
+              <button
+                className={`session-view-toggle__button ${viewMode === 'cards' ? 'active' : ''}`}
+                type="button"
+                onClick={() => setViewMode('cards')}
+                aria-pressed={viewMode === 'cards'}
+              >
+                Card View
+              </button>
+              <button
+                className={`session-view-toggle__button ${viewMode === 'table' ? 'active' : ''}`}
+                type="button"
+                onClick={() => setViewMode('table')}
+                aria-pressed={viewMode === 'table'}
+              >
+                Table View
+              </button>
+            </div>
+            <div className="session-count">
+              {filteredAndSortedSessions.length} of {sessions.length} sessions
+            </div>
           </div>
 
           {showComparison && (

--- a/frontend/src/components/SessionListView.css
+++ b/frontend/src/components/SessionListView.css
@@ -36,3 +36,61 @@
   padding: 0.6rem 0.75rem;
   box-sizing: border-box;
 }
+
+.session-list-view--table {
+  height: 100%;
+  min-height: 0;
+}
+
+.session-table-container {
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+}
+
+.session-table {
+  width: 100%;
+  min-width: 920px;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+
+.session-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0.55rem 0.7rem;
+  text-align: left;
+  white-space: nowrap;
+  font-weight: 600;
+  color: #334155;
+}
+
+.session-table tbody td {
+  border-bottom: 1px solid #eef2f7;
+  padding: 0.55rem 0.7rem;
+  color: #1f2937;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 280px;
+}
+
+.session-table tbody tr {
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.session-table tbody tr:hover {
+  background: #f8fbff;
+}
+
+.session-table tbody tr.selected {
+  background: #dbeafe;
+}
+
+.session-table tbody tr.selected td {
+  border-bottom-color: #bfdbfe;
+}

--- a/frontend/src/components/SessionListView.tsx
+++ b/frontend/src/components/SessionListView.tsx
@@ -1,6 +1,7 @@
 /**
  * SessionListView component displays a virtualized list of sessions with:
  * - Virtual scrolling (react-window) for handling 200+ sessions efficiently
+ * - Optional compact table mode for dense scanning
  * - SessionCard rendering for each session
  * - Selected state management
  * - Empty state message
@@ -16,6 +17,7 @@ interface SessionListViewProps {
   sessions: SessionSummary[];
   selectedId?: string | null;
   onSelect: (id: string) => void;
+  viewMode?: 'cards' | 'table';
 }
 
 const ITEM_SIZE = 188; // SessionCard row height
@@ -26,6 +28,7 @@ export function SessionListView({
   sessions,
   selectedId,
   onSelect,
+  viewMode = 'cards',
 }: SessionListViewProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [listHeight, setListHeight] = useState<number>(FALLBACK_LIST_HEIGHT);
@@ -54,6 +57,63 @@ export function SessionListView({
       <div className="session-list-view" ref={containerRef}>
         <div className="session-list-empty">
           <p>No sessions found</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (viewMode === 'table') {
+    return (
+      <div className="session-list-view session-list-view--table" ref={containerRef}>
+        <div className="session-table-container">
+          <table className="session-table">
+            <thead>
+              <tr>
+                <th>Session</th>
+                <th>Ecosystem</th>
+                <th>Project</th>
+                <th>Updated</th>
+                <th>Tokens</th>
+                <th>Messages</th>
+                <th>Bottleneck</th>
+                <th>Automation</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessions.map((session) => {
+                const updated = session.updated_at || session.created_at;
+                const automation = session.automation_ratio === null
+                  ? '--'
+                  : `${session.automation_ratio.toFixed(2)}x`;
+                return (
+                  <tr
+                    key={session.session_id}
+                    data-session-id={session.session_id}
+                    className={session.session_id === selectedId ? 'selected' : ''}
+                    onClick={() => onSelect(session.session_id)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        onSelect(session.session_id);
+                      }
+                    }}
+                    tabIndex={0}
+                  >
+                    <td title={session.session_id}>
+                      <code>{session.session_id.slice(0, 12)}</code>
+                    </td>
+                    <td>{session.ecosystem}</td>
+                    <td title={session.project_path}>{session.project_path}</td>
+                    <td>{new Date(updated).toLocaleString()}</td>
+                    <td>{session.total_tokens.toLocaleString()}</td>
+                    <td>{session.total_messages.toLocaleString()}</td>
+                    <td>{session.bottleneck ?? '--'}</td>
+                    <td>{automation}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
         </div>
       </div>
     );

--- a/frontend/tests/session-table-mode.spec.ts
+++ b/frontend/tests/session-table-mode.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * E2E tests for compact session table mode.
+ */
+
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+const mockTableSessions = {
+  sessions: [
+    {
+      session_id: 'session-alpha',
+      ecosystem: 'claude_code',
+      project_path: '/workspace/alpha',
+      created_at: '2026-02-10T09:00:00Z',
+      updated_at: '2026-02-10T11:00:00Z',
+      total_messages: 28,
+      total_tokens: 12000,
+      git_branch: 'main',
+      version: '1.0.0',
+      parsed_at: null,
+      duration_seconds: 5400,
+      bottleneck: 'Model',
+      automation_ratio: 1.8,
+    },
+    {
+      session_id: 'session-beta',
+      ecosystem: 'codex',
+      project_path: '/workspace/beta',
+      created_at: '2026-02-08T08:00:00Z',
+      updated_at: '2026-02-08T09:30:00Z',
+      total_messages: 64,
+      total_tokens: 50000,
+      git_branch: 'feat/api',
+      version: '1.0.0',
+      parsed_at: null,
+      duration_seconds: 8400,
+      bottleneck: 'Tool',
+      automation_ratio: 3.2,
+    },
+    {
+      session_id: 'session-gamma',
+      ecosystem: 'claude_code',
+      project_path: '/workspace/gamma',
+      created_at: '2026-02-12T06:00:00Z',
+      updated_at: '2026-02-12T12:15:00Z',
+      total_messages: 18,
+      total_tokens: 8000,
+      git_branch: 'main',
+      version: '1.0.0',
+      parsed_at: null,
+      duration_seconds: 4200,
+      bottleneck: 'User',
+      automation_ratio: 0.9,
+    },
+  ],
+  count: 3,
+  page: 1,
+  page_size: 200,
+  total_pages: 1,
+};
+
+async function setupTableModeMockApi(page: Page): Promise<void> {
+  await page.route(/\/api\/sessions(\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockTableSessions),
+    });
+  });
+
+  await page.route(/\/api\/sessions\/session-[^/]+$/, async (route) => {
+    const sessionId = route.request().url().split('/').pop() || 'session-alpha';
+    const session = mockTableSessions.sessions.find((item) => item.session_id === sessionId);
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session: {
+          metadata: {
+            session_id: sessionId,
+            project_path: session?.project_path || '/workspace/unknown',
+            git_branch: session?.git_branch || 'main',
+            version: session?.version || '1.0.0',
+            created_at: session?.created_at || '2026-02-01T00:00:00Z',
+            updated_at: session?.updated_at || '2026-02-01T00:00:00Z',
+            total_messages: session?.total_messages || 0,
+            total_tokens: session?.total_tokens || 0,
+          },
+          messages: [],
+        },
+      }),
+    });
+  });
+
+  await page.route(/\/api\/sessions\/session-[^/]+\/statistics$/, async (route) => {
+    const sessionId = route.request().url().split('/').at(-2) || 'session-alpha';
+    const session = mockTableSessions.sessions.find((item) => item.session_id === sessionId);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session_id: sessionId,
+        statistics: {
+          message_count: session?.total_messages || 0,
+          user_message_count: 8,
+          assistant_message_count: 10,
+          system_message_count: 0,
+          total_tokens: session?.total_tokens || 0,
+          total_input_tokens: 4000,
+          total_output_tokens: 4000,
+          cache_read_tokens: 200,
+          cache_creation_tokens: 100,
+          tool_calls: [],
+          tool_groups: [],
+          total_tool_calls: 0,
+          tool_error_records: [],
+          tool_error_category_counts: {},
+          error_taxonomy_version: '1.0.0',
+          subagent_count: 0,
+          subagent_sessions: {},
+          session_duration_seconds: session?.duration_seconds || 0,
+          first_message_time: session?.created_at || '2026-02-01T00:00:00Z',
+          last_message_time: session?.updated_at || '2026-02-01T00:00:00Z',
+        },
+      }),
+    });
+  });
+}
+
+test.describe('@full Session Table Mode', () => {
+  test('should render compact table and select rows while preserving filters', async ({ page }) => {
+    const requestedSessionDetails: string[] = [];
+    page.on('request', (request) => {
+      if (
+        request.url().includes('/api/sessions/session-') &&
+        !request.url().includes('/statistics')
+      ) {
+        requestedSessionDetails.push(request.url());
+      }
+    });
+
+    await setupTableModeMockApi(page);
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'Table View' }).click();
+    await page.waitForSelector('.session-table', { timeout: 10000 });
+
+    await expect(page.locator('.session-table thead')).toContainText('Ecosystem');
+    await expect(page.locator('.session-table thead')).toContainText('Automation');
+
+    const alphaRow = page.locator('tr[data-session-id="session-alpha"]');
+    await alphaRow.click();
+    await expect(alphaRow).toHaveClass(/selected/);
+
+    await expect
+      .poll(
+        () => requestedSessionDetails.some((url) => url.includes('/api/sessions/session-alpha')),
+        { timeout: 10000 }
+      )
+      .toBeTruthy();
+
+    await page.locator('.search-input').fill('session-alpha');
+    await page.waitForTimeout(500);
+    await expect(page.locator('.session-table tbody tr[data-session-id]')).toHaveCount(1);
+    await expect(page.locator('tr[data-session-id="session-alpha"]')).toBeVisible();
+  });
+
+  test('should apply existing sort options in table mode', async ({ page }) => {
+    await setupTableModeMockApi(page);
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Table View' }).click();
+    await page.waitForSelector('.session-table', { timeout: 10000 });
+
+    await page.locator('.sort-select').selectOption('tokens');
+    const firstByTokens = page.locator('.session-table tbody tr[data-session-id]').first();
+    await expect(firstByTokens).toHaveAttribute('data-session-id', 'session-beta');
+
+    await page.locator('.sort-select').selectOption('updated');
+    const firstByUpdated = page.locator('.session-table tbody tr[data-session-id]').first();
+    await expect(firstByUpdated).toHaveAttribute('data-session-id', 'session-gamma');
+  });
+});


### PR DESCRIPTION
## Summary\n- add card/table view toggle in session browser for dense session scanning\n- implement compact table rows with required columns (session, ecosystem, project, updated, tokens, messages, bottleneck, automation)\n- keep existing search/sort/date filtering and row selection behavior in table mode\n- add horizontal scroll-safe table container for smaller screens\n- add Playwright coverage for table-mode selection/filtering and sorting behavior\n\n## Validation\n- npm --prefix frontend run lint -- src/components/SessionBrowser.tsx src/components/SessionListView.tsx tests/session-table-mode.spec.ts\n- npm --prefix frontend run type-check\n- npm --prefix frontend run test:e2e -- tests/session-table-mode.spec.ts --project=chromium\n- npm --prefix frontend run test:e2e -- tests/session-browser.spec.ts tests/session-table-mode.spec.ts --project=chromium