### PR TITLE
feat: add active-time ratio and tri-part time analytics UI (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Regression fixtures/tests for taxonomy precision and fallback behavior (`tests/fixtures/error_taxonomy_examples.json`, `tests/test_error_taxonomy.py`).
 - Playwright smoke tests for tool error timeline rendering, expand/collapse details, and table scroll-container behavior on metrics dashboard.
 - Compact session table mode in session browser with row-based selection, ecosystem column, and dense cross-session scan layout.
+- Active-time analytics enhancements: explicit `active_time_ratio` in session time breakdown and cross-session overview API payloads.
 
 ### Changed
 
@@ -31,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Session sync and service initialization now support mixed local roots (Claude + Codex), and session list responses now expose ecosystem metadata.
 - Statistics dashboard now includes taxonomy-aware tool error timeline table with category chips and expandable raw error detail rows.
 - Session browser supports explicit card/table mode toggle while reusing existing search/sort/date filters and selection behavior in both views.
+- Time breakdown visualization now presents Model/Tool/User metric cards, excludes inactive time from pie-chart denominator, and displays active-time ratio directly.
 
 ## [0.6.0] - 2026-02-26
 

--- a/claude_vis/api/models.py
+++ b/claude_vis/api/models.py
@@ -137,6 +137,7 @@ class AnalyticsOverviewResponse(BaseModel):
     tool_time_seconds: float
     user_time_seconds: float
     inactive_time_seconds: float
+    active_time_ratio: float
     model_timeout_count: int
     bottleneck_distribution: list[AnalyticsBucket]
     top_projects: list[ProjectAggregate]

--- a/claude_vis/api/service.py
+++ b/claude_vis/api/service.py
@@ -378,6 +378,7 @@ class SessionService:
                 tool_time_seconds=0.0,
                 user_time_seconds=0.0,
                 inactive_time_seconds=0.0,
+                active_time_ratio=0.0,
                 model_timeout_count=0,
                 bottleneck_distribution=[],
                 top_projects=[],
@@ -532,6 +533,10 @@ class SessionService:
         top_tools.sort(key=lambda item: item.total_calls, reverse=True)
         top_tools = top_tools[:15]
 
+        total_active_time = model_time_seconds + tool_time_seconds + user_time_seconds
+        total_span_time = total_active_time + inactive_time_seconds
+        active_time_ratio = total_active_time / total_span_time if total_span_time > 0 else 0.0
+
         return AnalyticsOverviewResponse(
             start_date=start_date,
             end_date=end_date,
@@ -549,6 +554,7 @@ class SessionService:
             tool_time_seconds=tool_time_seconds,
             user_time_seconds=user_time_seconds,
             inactive_time_seconds=inactive_time_seconds,
+            active_time_ratio=active_time_ratio,
             model_timeout_count=model_timeout_count,
             bottleneck_distribution=bottleneck_distribution,
             top_projects=top_projects,

--- a/claude_vis/models.py
+++ b/claude_vis/models.py
@@ -230,6 +230,7 @@ class TimeBreakdown(BaseModel):
     tool_time_percent: float = 0.0
     user_time_percent: float = 0.0
     inactive_time_percent: float = 0.0
+    active_time_ratio: float = 0.0
     inactivity_threshold_seconds: float = 1800.0
     user_interaction_count: int = 0
     interactions_per_hour: float = 0.0

--- a/claude_vis/parsers/claude_code.py
+++ b/claude_vis/parsers/claude_code.py
@@ -692,6 +692,7 @@ def calculate_session_statistics(
             tool_time_percent=round(total_tool_time / total_active_time * 100, 1) if total_active_time > 0 else 0.0,
             user_time_percent=round(total_user_time / total_active_time * 100, 1) if total_active_time > 0 else 0.0,
             inactive_time_percent=round(total_inactive_time / total_span_time * 100, 1),
+            active_time_ratio=round(total_active_time / total_span_time, 4),
             inactivity_threshold_seconds=inactivity_threshold,
             user_interaction_count=user_interaction_count,
             interactions_per_hour=interactions_per_hour,

--- a/frontend/src/components/CrossSessionOverview.tsx
+++ b/frontend/src/components/CrossSessionOverview.tsx
@@ -231,7 +231,7 @@ export function CrossSessionOverview() {
         <article className="kpi-card">
           <h4>Automation efficiency</h4>
           <div className="kpi-value">{overview.avg_automation_ratio.toFixed(2)}x</div>
-          <p>Avg session duration: {formatDuration(overview.avg_session_duration_seconds)}</p>
+          <p>Active ratio: {formatPercent(overview.active_time_ratio * 100)}</p>
         </article>
 
         <article className="kpi-card">
@@ -246,7 +246,11 @@ export function CrossSessionOverview() {
         <article className="kpi-card">
           <h4>Tool execution</h4>
           <div className="kpi-value">{formatNumber(overview.total_tool_calls)}</div>
-          <p>Model timeouts: {formatNumber(overview.model_timeout_count)}</p>
+          <p>
+            Avg session duration: {formatDuration(overview.avg_session_duration_seconds)} ·
+            {' '}
+            Model timeouts: {formatNumber(overview.model_timeout_count)}
+          </p>
         </article>
       </div>
 

--- a/frontend/src/components/TimeBreakdownChart.css
+++ b/frontend/src/components/TimeBreakdownChart.css
@@ -30,6 +30,47 @@
   color: #6b7280;
 }
 
+.time-breakdown-chart .chart-header .active-ratio-text {
+  margin-top: 4px;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.time-breakdown-chart .time-category-grid {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.time-breakdown-chart .time-category-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #f8fafc;
+}
+
+.time-breakdown-chart .time-category-card h4 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 6px 0;
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.time-breakdown-chart .time-category-card .time-value {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.time-breakdown-chart .time-category-card .time-percent {
+  margin: 2px 0 0;
+  font-size: 0.78rem;
+  color: #475569;
+}
+
 .time-breakdown-chart .charts-container {
   display: flex;
   flex-direction: column;
@@ -43,7 +84,32 @@
 .time-breakdown-chart .pie-chart-section {
   width: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
+}
+
+.time-breakdown-chart .pie-scope-note {
+  margin: 0 0 8px;
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+.time-breakdown-chart .pie-scope-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.time-breakdown-chart .pie-scope-item {
+  border: 1px solid #dbe5ef;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  color: #334155;
+  background: #f8fbff;
 }
 
 .time-breakdown-chart .time-legend {
@@ -103,6 +169,10 @@
 
 /* Responsive */
 @media (min-width: 768px) {
+  .time-breakdown-chart .time-category-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .time-breakdown-chart .charts-container {
     flex-direction: row;
   }
@@ -119,6 +189,10 @@
 @media (max-width: 768px) {
   .time-breakdown-chart {
     padding: 16px;
+  }
+
+  .time-breakdown-chart .time-category-grid {
+    grid-template-columns: 1fr;
   }
 
   .time-breakdown-chart .time-legend {

--- a/frontend/src/components/TimeBreakdownChart.tsx
+++ b/frontend/src/components/TimeBreakdownChart.tsx
@@ -7,7 +7,7 @@
  * - User (human response time)
  * - Inactive (idle time >30min)
  *
- * Renders as horizontal stacked bar chart and optional pie chart.
+ * Renders as horizontal stacked bar chart and active-time-only pie chart.
  */
 
 import {
@@ -32,6 +32,17 @@ interface TimeBreakdownChartProps {
   showBarChart?: boolean;
 }
 
+interface PieTooltipData {
+  name: string;
+  value: number;
+  percent: number;
+}
+
+interface PieTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: PieTooltipData }>;
+}
+
 const COLORS = {
   model: '#ef4444',    // Red - high priority
   tool: '#f97316',     // Orange - medium priority
@@ -41,7 +52,7 @@ const COLORS = {
 
 const formatTime = (seconds: number): string => {
   if (seconds === 0) return '0s';
-  
+
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   const secs = Math.floor(seconds % 60);
@@ -53,6 +64,23 @@ const formatTime = (seconds: number): string => {
 
   return parts.join(' ');
 };
+
+function CustomPieTooltip({ active, payload }: PieTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const data = payload[0].payload;
+  return (
+    <div className="custom-tooltip">
+      <p className="label">{data.name}</p>
+      <p className="value">
+        <strong>{formatTime(data.value)}</strong>
+      </p>
+      <p className="percent">{data.percent.toFixed(1)}%</p>
+    </div>
+  );
+}
 
 export function TimeBreakdownChart({
   timeBreakdown,
@@ -66,6 +94,15 @@ export function TimeBreakdownChart({
       </div>
     );
   }
+
+  const totalSpanTime = timeBreakdown.total_active_time_seconds + timeBreakdown.total_inactive_time_seconds;
+  const computedActiveRatio = totalSpanTime > 0
+    ? timeBreakdown.total_active_time_seconds / totalSpanTime
+    : 0;
+  const activeTimeRatio = typeof timeBreakdown.active_time_ratio === 'number'
+    ? timeBreakdown.active_time_ratio
+    : computedActiveRatio;
+  const activeTimeRatioPercent = activeTimeRatio * 100;
 
   // Prepare data for stacked bar chart
   const barData = [
@@ -98,13 +135,28 @@ export function TimeBreakdownChart({
       percent: timeBreakdown.user_time_percent,
       color: COLORS.user,
     },
-    {
-      name: 'Inactive',
-      value: timeBreakdown.total_inactive_time_seconds,
-      percent: timeBreakdown.inactive_time_percent,
-      color: COLORS.inactive,
-    },
   ].filter((item) => item.value > 0); // Only show non-zero categories
+
+  const categoryCards = [
+    {
+      label: 'Model',
+      time: timeBreakdown.total_model_time_seconds,
+      percent: timeBreakdown.model_time_percent,
+      color: COLORS.model,
+    },
+    {
+      label: 'Tool',
+      time: timeBreakdown.total_tool_time_seconds,
+      percent: timeBreakdown.tool_time_percent,
+      color: COLORS.tool,
+    },
+    {
+      label: 'User',
+      time: timeBreakdown.total_user_time_seconds,
+      percent: timeBreakdown.user_time_percent,
+      color: COLORS.user,
+    },
+  ];
 
   const renderCustomLabel = ({
     cx,
@@ -122,7 +174,7 @@ export function TimeBreakdownChart({
     percent?: number;
   }) => {
     // Guard clause to handle undefined values from Recharts
-    if (cx === undefined || cy === undefined || midAngle === undefined || 
+    if (cx === undefined || cy === undefined || midAngle === undefined ||
         innerRadius === undefined || outerRadius === undefined || percent === undefined) {
       return null;
     }
@@ -148,30 +200,30 @@ export function TimeBreakdownChart({
     );
   };
 
-  const CustomTooltip = ({ active, payload }: any) => {
-    if (active && payload && payload.length > 0) {
-      const data = payload[0].payload;
-      return (
-        <div className="custom-tooltip">
-          <p className="label">{data.name}</p>
-          <p className="value">
-            <strong>{formatTime(data.value)}</strong>
-          </p>
-          <p className="percent">{data.percent.toFixed(1)}%</p>
-        </div>
-      );
-    }
-    return null;
-  };
-
   return (
     <div className="time-breakdown-chart">
       <div className="chart-header">
         <h3>Time Distribution</h3>
         <p className="subtitle">
-          Active: {formatTime(timeBreakdown.total_active_time_seconds)} | 
+          Active: {formatTime(timeBreakdown.total_active_time_seconds)} |
           Inactive: {formatTime(timeBreakdown.total_inactive_time_seconds)}
         </p>
+        <p className="subtitle active-ratio-text">
+          Active ratio: {activeTimeRatioPercent.toFixed(1)}%
+        </p>
+      </div>
+
+      <div className="time-category-grid">
+        {categoryCards.map((item) => (
+          <article key={item.label} className="time-category-card">
+            <h4>
+              <span className="legend-color" style={{ backgroundColor: item.color }}></span>
+              {item.label}
+            </h4>
+            <p className="time-value">{formatTime(item.time)}</p>
+            <p className="time-percent">{item.percent.toFixed(1)}% of active time</p>
+          </article>
+        ))}
       </div>
 
       <div className="charts-container">
@@ -228,6 +280,7 @@ export function TimeBreakdownChart({
 
         {showPieChart && pieData.length > 0 && (
           <div className="pie-chart-section">
+            <p className="pie-scope-note">Pie chart scope: active time only (Model/Tool/User).</p>
             <ResponsiveContainer width="100%" height={300}>
               <PieChart>
                 <Pie
@@ -244,9 +297,16 @@ export function TimeBreakdownChart({
                     <Cell key={`cell-${index}`} fill={entry.color} />
                   ))}
                 </Pie>
-                <Tooltip content={<CustomTooltip />} />
+                <Tooltip content={<CustomPieTooltip />} />
               </PieChart>
             </ResponsiveContainer>
+            <div className="pie-scope-list" aria-label="Pie categories">
+              {pieData.map((entry) => (
+                <span key={entry.name} className="pie-scope-item">
+                  {entry.name}
+                </span>
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -197,6 +197,7 @@ export interface TimeBreakdown {
   tool_time_percent: number;
   user_time_percent: number;
   inactive_time_percent: number;
+  active_time_ratio: number;
   inactivity_threshold_seconds: number;
   user_interaction_count: number;
   interactions_per_hour: number;
@@ -343,6 +344,7 @@ export interface AnalyticsOverviewResponse {
   tool_time_seconds: number;
   user_time_seconds: number;
   inactive_time_seconds: number;
+  active_time_ratio: number;
   model_timeout_count: number;
   bottleneck_distribution: AnalyticsBucket[];
   top_projects: ProjectAggregate[];

--- a/frontend/tests/time-breakdown-analytics.spec.ts
+++ b/frontend/tests/time-breakdown-analytics.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * E2E tests for time breakdown analytics presentation.
+ */
+
+import { test, expect } from '@playwright/test';
+import { setupMockApi } from './fixtures/mockServer';
+import { mockSessionStatistics } from './fixtures/mockData';
+
+test.describe('@full Time Breakdown Analytics', () => {
+  test('should show Model/Tool/User sections and active-time-only pie scope', async ({ page }) => {
+    await setupMockApi(page);
+
+    await page.route(/\/api\/sessions\/test-session-(001|002)\/statistics$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSessionStatistics,
+          statistics: {
+            ...mockSessionStatistics.statistics,
+            time_breakdown: {
+              total_model_time_seconds: 120,
+              total_tool_time_seconds: 60,
+              total_user_time_seconds: 20,
+              total_inactive_time_seconds: 100,
+              total_active_time_seconds: 200,
+              model_time_percent: 60,
+              tool_time_percent: 30,
+              user_time_percent: 10,
+              inactive_time_percent: 33.3,
+              active_time_ratio: 0.6667,
+              inactivity_threshold_seconds: 1800,
+              user_interaction_count: 5,
+              interactions_per_hour: 90,
+              model_timeout_count: 1,
+              model_timeout_threshold_seconds: 600,
+            },
+          },
+        }),
+      });
+    });
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Statistics' }).click();
+    await page.waitForSelector('.time-breakdown-chart', { timeout: 10000 });
+
+    await expect(page.locator('.active-ratio-text')).toContainText('66.7%');
+    await expect(page.locator('.time-category-card')).toHaveCount(3);
+    await expect(page.locator('.time-category-card').first()).toContainText('Model');
+    await expect(page.locator('.time-category-card').nth(1)).toContainText('Tool');
+    await expect(page.locator('.time-category-card').nth(2)).toContainText('User');
+
+    await expect(page.locator('.pie-scope-note')).toContainText('active time only');
+    await expect(page.locator('.pie-scope-list .pie-scope-item')).toHaveCount(3);
+    await expect(page.locator('.pie-scope-list')).not.toContainText('Inactive');
+  });
+});

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -288,6 +288,7 @@ class TestAnalyticsAPI:
         assert "total_sessions" in payload
         assert "total_tokens" in payload
         assert "bottleneck_distribution" in payload
+        assert "active_time_ratio" in payload
 
         start = date.fromisoformat(payload["start_date"])
         end = date.fromisoformat(payload["end_date"])
@@ -306,6 +307,16 @@ class TestAnalyticsAPI:
         assert payload["total_sessions"] >= 1
         assert payload["total_messages"] >= 1
         assert payload["total_tokens"] >= 1
+        assert 0.0 <= payload["active_time_ratio"] <= 1.0
+
+        active = (
+            payload["model_time_seconds"]
+            + payload["tool_time_seconds"]
+            + payload["user_time_seconds"]
+        )
+        span = active + payload["inactive_time_seconds"]
+        expected_ratio = active / span if span > 0 else 0.0
+        assert payload["active_time_ratio"] == pytest.approx(expected_ratio, abs=1e-9)
 
     def test_analytics_distribution_tool(
         self, test_client: TestClient

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -788,6 +788,11 @@ class TestConfigurableThresholds:
         # 55 min gap should be inactive (> 30 min default)
         assert tbd.total_inactive_time_seconds > 0
         assert tbd.inactivity_threshold_seconds == 1800.0
+        total_span = tbd.total_active_time_seconds + tbd.total_inactive_time_seconds
+        assert total_span > 0
+        assert tbd.active_time_ratio == pytest.approx(
+            tbd.total_active_time_seconds / total_span, abs=1e-4
+        )
 
     def test_custom_inactivity_threshold_lower(self, messages_with_large_gaps: Path) -> None:
         """Test with a 600s (10 min) threshold: 12-min and 15-min gaps become inactive too."""
@@ -817,6 +822,7 @@ class TestConfigurableThresholds:
         # 55 min gap (3300s) should NOT be inactive with 7200s threshold
         assert stats.time_breakdown.total_inactive_time_seconds == 0.0
         assert stats.time_breakdown.inactivity_threshold_seconds == 7200.0
+        assert stats.time_breakdown.active_time_ratio == 1.0
 
     def test_model_timeout_detection_default(self, messages_with_large_gaps: Path) -> None:
         """Test model timeout detection with default 600s threshold."""


### PR DESCRIPTION
## Summary
- add `active_time_ratio` to backend time analytics contracts (session breakdown + overview API)
- compute active ratio from active/span time in analytics service
- update time breakdown visualization to show explicit Model/Tool/User cards
- exclude inactive time from pie-chart scope and surface active-ratio text in UI
- add frontend and backend tests for active-ratio math and active-only pie scope

## Validation
- uv run ruff check claude_vis/models.py claude_vis/parsers/claude_code.py claude_vis/api/models.py claude_vis/api/service.py tests/test_statistics.py tests/test_api_integration.py --ignore E501
- uv run pytest tests/test_statistics.py tests/test_api_integration.py::TestAnalyticsAPI::test_analytics_overview_default_range tests/test_api_integration.py::TestAnalyticsAPI::test_analytics_overview_with_explicit_range -q
- npm --prefix frontend run lint -- src/components/TimeBreakdownChart.tsx src/components/CrossSessionOverview.tsx tests/time-breakdown-analytics.spec.ts
- npm --prefix frontend run type-check
- npm --prefix frontend run test:e2e -- tests/time-breakdown-analytics.spec.ts --project=chromium
