### PR TITLE
feat: add trajectory size and multilingual character metrics (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Playwright smoke tests for tool error timeline rendering, expand/collapse details, and table scroll-container behavior on metrics dashboard.
 - Compact session table mode in session browser with row-based selection, ecosystem column, and dense cross-session scan layout.
 - Active-time analytics enhancements: explicit `active_time_ratio` in session time breakdown and cross-session overview API payloads.
+- Trajectory file-size and character analytics (`character_breakdown`) for per-session statistics and cross-session aggregates.
 
 ### Changed
 
@@ -33,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Statistics dashboard now includes taxonomy-aware tool error timeline table with category chips and expandable raw error detail rows.
 - Session browser supports explicit card/table mode toggle while reusing existing search/sort/date filters and selection behavior in both views.
 - Time breakdown visualization now presents Model/Tool/User metric cards, excludes inactive time from pie-chart denominator, and displays active-time ratio directly.
+- Resource views now surface trajectory bytes and mixed-language character metrics (CJK/Latin plus user/model/tool attribution) in both session and cross-session dashboards.
 
 ## [0.6.0] - 2026-02-26
 

--- a/claude_vis/api/models.py
+++ b/claude_vis/api/models.py
@@ -131,6 +131,14 @@ class AnalyticsOverviewResponse(BaseModel):
     total_output_tokens: int
     total_cache_read_tokens: int
     total_cache_creation_tokens: int
+    total_trajectory_file_size_bytes: int
+    total_chars: int
+    total_user_chars: int
+    total_model_chars: int
+    total_tool_chars: int
+    total_cjk_chars: int
+    total_latin_chars: int
+    total_other_chars: int
     avg_automation_ratio: float
     avg_session_duration_seconds: float
     model_time_seconds: float

--- a/claude_vis/api/service.py
+++ b/claude_vis/api/service.py
@@ -372,6 +372,14 @@ class SessionService:
                 total_output_tokens=0,
                 total_cache_read_tokens=0,
                 total_cache_creation_tokens=0,
+                total_trajectory_file_size_bytes=0,
+                total_chars=0,
+                total_user_chars=0,
+                total_model_chars=0,
+                total_tool_chars=0,
+                total_cjk_chars=0,
+                total_latin_chars=0,
+                total_other_chars=0,
                 avg_automation_ratio=0.0,
                 avg_session_duration_seconds=0.0,
                 model_time_seconds=0.0,
@@ -407,6 +415,14 @@ class SessionService:
         total_output_tokens = 0
         total_cache_read_tokens = 0
         total_cache_creation_tokens = 0
+        total_trajectory_file_size_bytes = 0
+        total_chars = 0
+        total_user_chars = 0
+        total_model_chars = 0
+        total_tool_chars = 0
+        total_cjk_chars = 0
+        total_latin_chars = 0
+        total_other_chars = 0
         model_time_seconds = 0.0
         tool_time_seconds = 0.0
         user_time_seconds = 0.0
@@ -451,6 +467,16 @@ class SessionService:
             total_output_tokens += int(stats.get("total_output_tokens") or 0)
             total_cache_read_tokens += int(stats.get("cache_read_tokens") or 0)
             total_cache_creation_tokens += int(stats.get("cache_creation_tokens") or 0)
+            total_trajectory_file_size_bytes += int(stats.get("trajectory_file_size_bytes") or 0)
+
+            char_stats = stats.get("character_breakdown") or {}
+            total_chars += int(char_stats.get("total_chars") or 0)
+            total_user_chars += int(char_stats.get("user_chars") or 0)
+            total_model_chars += int(char_stats.get("model_chars") or 0)
+            total_tool_chars += int(char_stats.get("tool_chars") or 0)
+            total_cjk_chars += int(char_stats.get("cjk_chars") or 0)
+            total_latin_chars += int(char_stats.get("latin_chars") or 0)
+            total_other_chars += int(char_stats.get("other_chars") or 0)
 
             time_breakdown = stats.get("time_breakdown") or {}
             model_time_seconds += float(time_breakdown.get("total_model_time_seconds") or 0.0)
@@ -548,6 +574,14 @@ class SessionService:
             total_output_tokens=total_output_tokens,
             total_cache_read_tokens=total_cache_read_tokens,
             total_cache_creation_tokens=total_cache_creation_tokens,
+            total_trajectory_file_size_bytes=total_trajectory_file_size_bytes,
+            total_chars=total_chars,
+            total_user_chars=total_user_chars,
+            total_model_chars=total_model_chars,
+            total_tool_chars=total_tool_chars,
+            total_cjk_chars=total_cjk_chars,
+            total_latin_chars=total_latin_chars,
+            total_other_chars=total_other_chars,
             avg_automation_ratio=mean(automation_values) if automation_values else 0.0,
             avg_session_duration_seconds=mean(duration_values) if duration_values else 0.0,
             model_time_seconds=model_time_seconds,

--- a/claude_vis/models.py
+++ b/claude_vis/models.py
@@ -247,6 +247,20 @@ class TokenBreakdown(BaseModel):
     cache_creation_percent: float = 0.0
 
 
+class CharacterBreakdown(BaseModel):
+    """Character counts by producer and script family."""
+
+    total_chars: int = 0
+    user_chars: int = 0
+    model_chars: int = 0
+    tool_chars: int = 0
+    cjk_chars: int = 0
+    latin_chars: int = 0
+    digit_chars: int = 0
+    whitespace_chars: int = 0
+    other_chars: int = 0
+
+
 class ToolCallStatistics(BaseModel):
     """Statistics about tool calls in a session."""
 
@@ -378,6 +392,8 @@ class SessionStatistics(BaseModel):
     total_output_tokens: int
     cache_read_tokens: int = 0
     cache_creation_tokens: int = 0
+    trajectory_file_size_bytes: int = 0
+    character_breakdown: CharacterBreakdown = Field(default_factory=CharacterBreakdown)
 
     # Tool statistics
     tool_calls: list[ToolCallStatistics] = Field(default_factory=list)

--- a/claude_vis/parsers/claude_code.py
+++ b/claude_vis/parsers/claude_code.py
@@ -17,6 +17,7 @@ from claude_vis.exceptions import SessionParseError
 from claude_vis.models import (
     BashBreakdown,
     BashCommandStats,
+    CharacterBreakdown,
     CompactEvent,
     MessageRecord,
     ParsedSessionData,
@@ -228,6 +229,35 @@ def _extract_tool_result_text(content: str | list[dict[str, Any]] | Any) -> str:
     return str(content)
 
 
+def _classify_characters(text: str) -> dict[str, int]:
+    """Count text characters by script family."""
+    counts = {
+        "cjk": 0,
+        "latin": 0,
+        "digit": 0,
+        "whitespace": 0,
+        "other": 0,
+    }
+    for char in text:
+        code_point = ord(char)
+        if char.isspace():
+            counts["whitespace"] += 1
+        elif (
+            0x4E00 <= code_point <= 0x9FFF
+            or 0x3400 <= code_point <= 0x4DBF
+            or 0x3040 <= code_point <= 0x30FF
+            or 0xAC00 <= code_point <= 0xD7AF
+        ):
+            counts["cjk"] += 1
+        elif ("a" <= char <= "z") or ("A" <= char <= "Z"):
+            counts["latin"] += 1
+        elif char.isdigit():
+            counts["digit"] += 1
+        else:
+            counts["other"] += 1
+    return counts
+
+
 # ---------------------------------------------------------------------------
 # Public module-level functions (backward compatibility)
 # ---------------------------------------------------------------------------
@@ -377,6 +407,7 @@ def calculate_session_statistics(
     *,
     inactivity_threshold: float = 1800.0,
     model_timeout_threshold: float = 600.0,
+    trajectory_file_size_bytes: int = 0,
 ) -> SessionStatistics:
     """
     Calculate comprehensive statistics for a session.
@@ -437,6 +468,14 @@ def calculate_session_statistics(
     user_interaction_count = 0
     model_timeout_count = 0
     prev_timestamp: datetime | None = None
+    user_chars = 0
+    model_chars = 0
+    tool_chars = 0
+    cjk_chars = 0
+    latin_chars = 0
+    digit_chars = 0
+    whitespace_chars = 0
+    other_chars = 0
 
     for msg in messages:
         # Count message types
@@ -564,6 +603,18 @@ def calculate_session_statistics(
                                     else:
                                         tool_stats[tool_name]["success"] += 1
 
+                                    result_text = _extract_tool_result_text(
+                                        content_block.get("content", "")
+                                    )
+                                    if result_text:
+                                        counts = _classify_characters(result_text)
+                                        tool_chars += len(result_text)
+                                        cjk_chars += counts["cjk"]
+                                        latin_chars += counts["latin"]
+                                        digit_chars += counts["digit"]
+                                        whitespace_chars += counts["whitespace"]
+                                        other_chars += counts["other"]
+
                                     # Compute per-tool latency
                                     latency = (timestamp - use_timestamp).total_seconds()
                                     if latency >= 0:
@@ -595,6 +646,34 @@ def calculate_session_statistics(
                                             per_cmd_chars = result_chars // len(sub_cmds)
                                             for cmd in sub_cmds:
                                                 bash_command_output_chars[cmd] += per_cmd_chars
+
+                        elif block_type in ("text", "thinking"):
+                            text_value = content_block.get("text")
+                            if block_type == "thinking":
+                                text_value = content_block.get("thinking")
+                            if isinstance(text_value, str) and text_value:
+                                counts = _classify_characters(text_value)
+                                if msg.is_assistant_message:
+                                    model_chars += len(text_value)
+                                elif msg.is_user_message:
+                                    user_chars += len(text_value)
+                                cjk_chars += counts["cjk"]
+                                latin_chars += counts["latin"]
+                                digit_chars += counts["digit"]
+                                whitespace_chars += counts["whitespace"]
+                                other_chars += counts["other"]
+            elif isinstance(msg.message.content, str) and msg.message.content:
+                text_value = msg.message.content
+                counts = _classify_characters(text_value)
+                if msg.is_assistant_message:
+                    model_chars += len(text_value)
+                elif msg.is_user_message:
+                    user_chars += len(text_value)
+                cjk_chars += counts["cjk"]
+                latin_chars += counts["latin"]
+                digit_chars += counts["digit"]
+                whitespace_chars += counts["whitespace"]
+                other_chars += counts["other"]
 
         # Track subagent sessions
         if msg.is_subagent_message and msg.agentId:
@@ -753,6 +832,18 @@ def calculate_session_statistics(
         total_output_tokens=total_output_tokens,
         cache_read_tokens=cache_read_tokens,
         cache_creation_tokens=cache_creation_tokens,
+        trajectory_file_size_bytes=trajectory_file_size_bytes,
+        character_breakdown=CharacterBreakdown(
+            total_chars=user_chars + model_chars + tool_chars,
+            user_chars=user_chars,
+            model_chars=model_chars,
+            tool_chars=tool_chars,
+            cjk_chars=cjk_chars,
+            latin_chars=latin_chars,
+            digit_chars=digit_chars,
+            whitespace_chars=whitespace_chars,
+            other_chars=other_chars,
+        ),
         tool_calls=tool_call_list,
         tool_groups=tool_group_list,
         total_tool_calls=sum(int(tool_stats[t]["count"]) for t in tool_stats),
@@ -845,10 +936,16 @@ def parse_session_file(
     subagent_sessions = extract_subagent_sessions(messages)
 
     # Calculate statistics
+    try:
+        trajectory_file_size_bytes = file_path.stat().st_size
+    except OSError:
+        trajectory_file_size_bytes = 0
+
     statistics = calculate_session_statistics(
         messages,
         inactivity_threshold=inactivity_threshold,
         model_timeout_threshold=model_timeout_threshold,
+        trajectory_file_size_bytes=trajectory_file_size_bytes,
     )
 
     # Extract compact events from raw JSONL (these aren't in MessageRecord)

--- a/frontend/src/components/CrossSessionOverview.tsx
+++ b/frontend/src/components/CrossSessionOverview.tsx
@@ -241,6 +241,16 @@ export function CrossSessionOverview() {
             Input/Output: {formatNumber(overview.total_input_tokens)} /{' '}
             {formatNumber(overview.total_output_tokens)}
           </p>
+          <p>
+            Trajectory size: {formatNumber(overview.total_trajectory_file_size_bytes)}
+            {' '}
+            bytes
+          </p>
+          <p>
+            Chars (CJK/Latin): {formatNumber(overview.total_cjk_chars)}
+            {' / '}
+            {formatNumber(overview.total_latin_chars)}
+          </p>
         </article>
 
         <article className="kpi-card">

--- a/frontend/src/components/StatisticsDashboard.tsx
+++ b/frontend/src/components/StatisticsDashboard.tsx
@@ -67,6 +67,18 @@ function formatDuration(seconds: number | null): string {
   return `${secs}s`;
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let idx = 0;
+  while (value >= 1024 && idx < units.length - 1) {
+    value /= 1024;
+    idx += 1;
+  }
+  return `${value.toFixed(value >= 10 || idx === 0 ? 0 : 1)} ${units[idx]}`;
+}
+
 function formatTimestamp(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -120,6 +132,17 @@ export function StatisticsDashboard({ sessionId }: StatisticsDashboardProps) {
   const toolErrorRecords = statistics.tool_error_records || [];
   const errorCategoryEntries = Object.entries(statistics.tool_error_category_counts || {})
     .sort((a, b) => b[1] - a[1]);
+  const characterBreakdown = statistics.character_breakdown || {
+    total_chars: 0,
+    user_chars: 0,
+    model_chars: 0,
+    tool_chars: 0,
+    cjk_chars: 0,
+    latin_chars: 0,
+    digit_chars: 0,
+    whitespace_chars: 0,
+    other_chars: 0,
+  };
 
   const toggleErrorDetail = (key: string): void => {
     setExpandedErrors((prev) => ({
@@ -590,6 +613,46 @@ export function StatisticsDashboard({ sessionId }: StatisticsDashboardProps) {
               <div className="breakdown-item">
                 <span className="breakdown-label">Created</span>
                 <span className="breakdown-value">{formatNumber(statistics.cache_creation_tokens)}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="stat-card">
+            <h4 className="card-title">Trajectory Size</h4>
+            <div className="stat-value large">{formatBytes(statistics.trajectory_file_size_bytes)}</div>
+            <div className="stat-breakdown">
+              <div className="breakdown-item">
+                <span className="breakdown-label">Raw bytes</span>
+                <span className="breakdown-value">
+                  {formatNumber(statistics.trajectory_file_size_bytes)}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="stat-card">
+            <h4 className="card-title">Character Volume</h4>
+            <div className="stat-value large">
+              {formatNumber(characterBreakdown.total_chars)}
+            </div>
+            <div className="stat-breakdown">
+              <div className="breakdown-item">
+                <span className="breakdown-label">CJK / Latin</span>
+                <span className="breakdown-value">
+                  {formatNumber(characterBreakdown.cjk_chars)}
+                  {' / '}
+                  {formatNumber(characterBreakdown.latin_chars)}
+                </span>
+              </div>
+              <div className="breakdown-item">
+                <span className="breakdown-label">User / Model / Tool</span>
+                <span className="breakdown-value">
+                  {formatNumber(characterBreakdown.user_chars)}
+                  {' / '}
+                  {formatNumber(characterBreakdown.model_chars)}
+                  {' / '}
+                  {formatNumber(characterBreakdown.tool_chars)}
+                </span>
               </div>
             </div>
           </div>

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -235,6 +235,18 @@ export interface ToolGroupStatistics {
   tools: string[];
 }
 
+export interface CharacterBreakdown {
+  total_chars: number;
+  user_chars: number;
+  model_chars: number;
+  tool_chars: number;
+  cjk_chars: number;
+  latin_chars: number;
+  digit_chars: number;
+  whitespace_chars: number;
+  other_chars: number;
+}
+
 export interface ToolErrorRecord {
   timestamp: string;
   tool_name: string;
@@ -277,6 +289,8 @@ export interface SessionStatistics {
   total_output_tokens: number;
   cache_read_tokens: number;
   cache_creation_tokens: number;
+  trajectory_file_size_bytes: number;
+  character_breakdown: CharacterBreakdown;
   tool_calls: ToolCallStatistics[];
   tool_groups: ToolGroupStatistics[];
   total_tool_calls: number;
@@ -338,6 +352,14 @@ export interface AnalyticsOverviewResponse {
   total_output_tokens: number;
   total_cache_read_tokens: number;
   total_cache_creation_tokens: number;
+  total_trajectory_file_size_bytes: number;
+  total_chars: number;
+  total_user_chars: number;
+  total_model_chars: number;
+  total_tool_chars: number;
+  total_cjk_chars: number;
+  total_latin_chars: number;
+  total_other_chars: number;
   avg_automation_ratio: number;
   avg_session_duration_seconds: number;
   model_time_seconds: number;

--- a/frontend/tests/cross-session-char-metrics.spec.ts
+++ b/frontend/tests/cross-session-char-metrics.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * E2E tests for cross-session file size and character metrics.
+ */
+
+import { test, expect } from '@playwright/test';
+import { setupMockApi } from './fixtures/mockServer';
+
+test.describe('@full Cross Session Char Metrics', () => {
+  test('should render trajectory size and CJK/Latin character totals in overview', async ({ page }) => {
+    await setupMockApi(page);
+
+    await page.route(/\/api\/analytics\/overview(\?.*)?$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          start_date: '2026-02-20',
+          end_date: '2026-02-26',
+          total_sessions: 12,
+          total_messages: 540,
+          total_tokens: 320000,
+          total_tool_calls: 860,
+          total_input_tokens: 180000,
+          total_output_tokens: 140000,
+          total_cache_read_tokens: 22000,
+          total_cache_creation_tokens: 9000,
+          total_trajectory_file_size_bytes: 987654,
+          total_chars: 450000,
+          total_user_chars: 120000,
+          total_model_chars: 250000,
+          total_tool_chars: 80000,
+          total_cjk_chars: 90000,
+          total_latin_chars: 330000,
+          total_other_chars: 30000,
+          avg_automation_ratio: 2.5,
+          avg_session_duration_seconds: 4200,
+          model_time_seconds: 36000,
+          tool_time_seconds: 22000,
+          user_time_seconds: 14000,
+          inactive_time_seconds: 8000,
+          active_time_ratio: 0.8788,
+          model_timeout_count: 3,
+          bottleneck_distribution: [
+            { key: 'model', label: 'Model', count: 7, value: 7, percent: 58.3 },
+            { key: 'tool', label: 'Tool', count: 4, value: 4, percent: 33.3 },
+            { key: 'user', label: 'User', count: 1, value: 1, percent: 8.4 },
+          ],
+          top_projects: [],
+          top_tools: [],
+        }),
+      });
+    });
+
+    await page.route(/\/api\/analytics\/distributions(\?.*)?$/, async (route) => {
+      const url = route.request().url();
+      const payload = url.includes('dimension=session_token_share')
+        ? {
+            dimension: 'session_token_share',
+            start_date: '2026-02-20',
+            end_date: '2026-02-26',
+            total: 100,
+            buckets: [],
+          }
+        : {
+            dimension: 'automation_band',
+            start_date: '2026-02-20',
+            end_date: '2026-02-26',
+            total: 12,
+            buckets: [],
+          };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(payload),
+      });
+    });
+
+    await page.route(/\/api\/analytics\/timeseries(\?.*)?$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          interval: 'day',
+          start_date: '2026-02-20',
+          end_date: '2026-02-26',
+          points: [
+            {
+              period: '2026-02-20',
+              sessions: 2,
+              tokens: 43000,
+              tool_calls: 120,
+              avg_automation_ratio: 2.1,
+              avg_duration_seconds: 3900,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Advanced Analytics' }).click();
+    await page.waitForSelector('.cross-session-overview', { timeout: 10000 });
+
+    await expect(page.locator('.kpi-card', { hasText: 'Token volume' })).toContainText(
+      'Trajectory size: 987,654 bytes'
+    );
+    await expect(page.locator('.kpi-card', { hasText: 'Token volume' })).toContainText(
+      'Chars (CJK/Latin): 90,000 / 330,000'
+    );
+  });
+});

--- a/frontend/tests/fixtures/mockData.ts
+++ b/frontend/tests/fixtures/mockData.ts
@@ -180,6 +180,18 @@ export const mockSessionStatistics: SessionStatisticsResponse = {
     total_output_tokens: 5000,
     cache_read_tokens: 2000,
     cache_creation_tokens: 500,
+    trajectory_file_size_bytes: 40960,
+    character_breakdown: {
+      total_chars: 24000,
+      user_chars: 6000,
+      model_chars: 14000,
+      tool_chars: 4000,
+      cjk_chars: 8000,
+      latin_chars: 14000,
+      digit_chars: 600,
+      whitespace_chars: 1200,
+      other_chars: 200,
+    },
     tool_calls: [
       {
         tool_name: 'Read',

--- a/frontend/tests/statistics-dashboard.spec.ts
+++ b/frontend/tests/statistics-dashboard.spec.ts
@@ -59,6 +59,8 @@ test.describe('@smoke Statistics Dashboard - Tool Errors', () => {
     await openStatisticsTab(page);
     await expect(page.locator('.dashboard-title')).toHaveText('Session Metrics');
     await expect(page.locator('.card-title', { hasText: 'Tool Error Timeline' })).toBeVisible();
+    await expect(page.locator('.card-title', { hasText: 'Trajectory Size' })).toBeVisible();
+    await expect(page.locator('.card-title', { hasText: 'Character Volume' })).toBeVisible();
 
     const categoryChips = page.locator('.error-category-chip');
     await expect(categoryChips).toHaveCount(2);

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -243,6 +243,8 @@ class TestSessionStatisticsAPI:
             assert "total_tokens" in stats
             assert "total_input_tokens" in stats
             assert "total_output_tokens" in stats
+            assert "trajectory_file_size_bytes" in stats
+            assert "character_breakdown" in stats
 
     def test_statistics_tool_call_data(self, test_client: TestClient) -> None:
         """Test that statistics include tool call information."""
@@ -289,6 +291,8 @@ class TestAnalyticsAPI:
         assert "total_tokens" in payload
         assert "bottleneck_distribution" in payload
         assert "active_time_ratio" in payload
+        assert "total_trajectory_file_size_bytes" in payload
+        assert "total_chars" in payload
 
         start = date.fromisoformat(payload["start_date"])
         end = date.fromisoformat(payload["end_date"])

--- a/tests/test_character_metrics.py
+++ b/tests/test_character_metrics.py
@@ -1,0 +1,90 @@
+"""Tests for trajectory file size and character metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_vis.parsers.session_parser import (
+    calculate_session_statistics,
+    parse_jsonl_file,
+    parse_session_file,
+)
+
+
+def test_character_breakdown_mixed_cjk_latin_digits(temp_session_dir: Path) -> None:
+    """Character classifier should separate CJK, Latin, and digits with source attribution."""
+    messages = [
+        {
+            "type": "user",
+            "sessionId": "char-metrics-001",
+            "uuid": "msg-1",
+            "timestamp": "2026-02-10T10:00:00.000Z",
+            "message": {"role": "user", "content": "你好abc"},
+        },
+        {
+            "type": "assistant",
+            "sessionId": "char-metrics-001",
+            "uuid": "msg-2",
+            "timestamp": "2026-02-10T10:00:01.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "测试xyz"},
+                    {"type": "tool_use", "id": "tool-1", "name": "Read", "input": {"path": "a.txt"}},
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "sessionId": "char-metrics-001",
+            "uuid": "msg-3",
+            "timestamp": "2026-02-10T10:00:02.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-1",
+                        "content": "错误404",
+                        "is_error": False,
+                    }
+                ],
+            },
+        },
+    ]
+    file_path = temp_session_dir / "char-metrics.jsonl"
+    with file_path.open("w", encoding="utf-8") as handle:
+        for message in messages:
+            handle.write(json.dumps(message) + "\n")
+
+    parsed_messages = parse_jsonl_file(file_path)
+    stats = calculate_session_statistics(parsed_messages)
+
+    chars = stats.character_breakdown
+    assert chars.total_chars == 15
+    assert chars.user_chars == 5
+    assert chars.model_chars == 5
+    assert chars.tool_chars == 5
+    assert chars.cjk_chars == 6
+    assert chars.latin_chars == 6
+    assert chars.digit_chars == 3
+    assert chars.whitespace_chars == 0
+    assert chars.other_chars == 0
+
+
+def test_parse_session_records_trajectory_file_size(temp_session_dir: Path) -> None:
+    """Parsed session statistics should include trajectory file size in bytes."""
+    file_path = temp_session_dir / "size-metrics.jsonl"
+    payload = {
+        "type": "user",
+        "sessionId": "char-metrics-002",
+        "uuid": "msg-1",
+        "timestamp": "2026-02-10T10:10:00.000Z",
+        "message": {"role": "user", "content": "hello"},
+    }
+    file_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    session = parse_session_file(file_path)
+    assert session.statistics is not None
+    assert session.statistics.trajectory_file_size_bytes == file_path.stat().st_size


### PR DESCRIPTION
## Summary
- add per-session trajectory file size bytes and `character_breakdown` (user/model/tool + CJK/Latin/digit/other) to statistics model
- compute character/script metrics during parser pass and persist trajectory file size from JSONL file metadata
- extend analytics overview API with aggregated file-size and character totals
- surface trajectory size and character metrics in single-session dashboard and cross-session overview
- add parser/API regression tests plus frontend E2E checks for new metric visibility

## Validation
- uv run ruff check claude_vis/models.py claude_vis/parsers/claude_code.py claude_vis/api/models.py claude_vis/api/service.py tests/test_statistics.py tests/test_api_integration.py tests/test_character_metrics.py --ignore E501
- uv run pytest tests/test_character_metrics.py tests/test_statistics.py tests/test_api_integration.py -q
- npm --prefix frontend run lint -- src/components/StatisticsDashboard.tsx src/components/CrossSessionOverview.tsx tests/statistics-dashboard.spec.ts tests/cross-session-char-metrics.spec.ts
- npm --prefix frontend run type-check
- npm --prefix frontend run test:e2e -- tests/statistics-dashboard.spec.ts tests/cross-session-char-metrics.spec.ts --project=chromium
