### PR TITLE
feat: add session and aggregate user yield ratios (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compact session table mode in session browser with row-based selection, ecosystem column, and dense cross-session scan layout.
 - Active-time analytics enhancements: explicit `active_time_ratio` in session time breakdown and cross-session overview API payloads.
 - Trajectory file-size and character analytics (`character_breakdown`) for per-session statistics and cross-session aggregates.
+- User-efficiency yield ratios for tokens/chars (`user_yield_ratio_tokens`, `user_yield_ratio_chars`) with cross-session mean/median/p90 aggregates.
 
 ### Changed
 
@@ -35,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Session browser supports explicit card/table mode toggle while reusing existing search/sort/date filters and selection behavior in both views.
 - Time breakdown visualization now presents Model/Tool/User metric cards, excludes inactive time from pie-chart denominator, and displays active-time ratio directly.
 - Resource views now surface trajectory bytes and mixed-language character metrics (CJK/Latin plus user/model/tool attribution) in both session and cross-session dashboards.
+- Automation panels now expose per-session and aggregated token/char yield ratios to measure output efficiency per unit of user input.
 
 ## [0.6.0] - 2026-02-26
 

--- a/claude_vis/api/models.py
+++ b/claude_vis/api/models.py
@@ -139,6 +139,12 @@ class AnalyticsOverviewResponse(BaseModel):
     total_cjk_chars: int
     total_latin_chars: int
     total_other_chars: int
+    yield_ratio_tokens_mean: float
+    yield_ratio_tokens_median: float
+    yield_ratio_tokens_p90: float
+    yield_ratio_chars_mean: float
+    yield_ratio_chars_median: float
+    yield_ratio_chars_p90: float
     avg_automation_ratio: float
     avg_session_duration_seconds: float
     model_time_seconds: float

--- a/claude_vis/api/service.py
+++ b/claude_vis/api/service.py
@@ -8,11 +8,12 @@ back to on-the-fly parsing when the database is empty.
 import asyncio
 import functools
 import json
+import math
 import sqlite3
 from collections import defaultdict
 from datetime import date, datetime
 from pathlib import Path
-from statistics import mean
+from statistics import mean, median
 from typing import Any, Literal, cast
 
 from claude_vis.api.models import (
@@ -380,6 +381,12 @@ class SessionService:
                 total_cjk_chars=0,
                 total_latin_chars=0,
                 total_other_chars=0,
+                yield_ratio_tokens_mean=0.0,
+                yield_ratio_tokens_median=0.0,
+                yield_ratio_tokens_p90=0.0,
+                yield_ratio_chars_mean=0.0,
+                yield_ratio_chars_median=0.0,
+                yield_ratio_chars_p90=0.0,
                 avg_automation_ratio=0.0,
                 avg_session_duration_seconds=0.0,
                 model_time_seconds=0.0,
@@ -428,6 +435,8 @@ class SessionService:
         user_time_seconds = 0.0
         inactive_time_seconds = 0.0
         model_timeout_count = 0
+        token_yield_ratios: list[float] = []
+        char_yield_ratios: list[float] = []
 
         tool_acc: dict[str, dict[str, float | int | set[str]]] = defaultdict(
             lambda: {
@@ -477,6 +486,30 @@ class SessionService:
             total_cjk_chars += int(char_stats.get("cjk_chars") or 0)
             total_latin_chars += int(char_stats.get("latin_chars") or 0)
             total_other_chars += int(char_stats.get("other_chars") or 0)
+
+            token_ratio = stats.get("user_yield_ratio_tokens")
+            if token_ratio is None:
+                denom_tokens = int(stats.get("total_input_tokens") or 0)
+                if denom_tokens > 0:
+                    output_tokens = int(stats.get("total_output_tokens") or 0)
+                    tool_tokens = sum(
+                        int(tool.get("total_tokens") or 0)
+                        for tool in (stats.get("tool_calls") or [])
+                    )
+                    token_ratio = (output_tokens + tool_tokens) / denom_tokens
+            if token_ratio is not None:
+                token_yield_ratios.append(float(token_ratio))
+
+            char_ratio = stats.get("user_yield_ratio_chars")
+            if char_ratio is None:
+                denom_chars = int(char_stats.get("user_chars") or 0)
+                if denom_chars > 0:
+                    output_chars = int(char_stats.get("model_chars") or 0) + int(
+                        char_stats.get("tool_chars") or 0
+                    )
+                    char_ratio = output_chars / denom_chars
+            if char_ratio is not None:
+                char_yield_ratios.append(float(char_ratio))
 
             time_breakdown = stats.get("time_breakdown") or {}
             model_time_seconds += float(time_breakdown.get("total_model_time_seconds") or 0.0)
@@ -562,6 +595,17 @@ class SessionService:
         total_active_time = model_time_seconds + tool_time_seconds + user_time_seconds
         total_span_time = total_active_time + inactive_time_seconds
         active_time_ratio = total_active_time / total_span_time if total_span_time > 0 else 0.0
+        token_p90 = 0.0
+        if token_yield_ratios:
+            sorted_token_ratios = sorted(token_yield_ratios)
+            idx = max(0, math.ceil(0.9 * len(sorted_token_ratios)) - 1)
+            token_p90 = sorted_token_ratios[idx]
+
+        chars_p90 = 0.0
+        if char_yield_ratios:
+            sorted_char_ratios = sorted(char_yield_ratios)
+            idx = max(0, math.ceil(0.9 * len(sorted_char_ratios)) - 1)
+            chars_p90 = sorted_char_ratios[idx]
 
         return AnalyticsOverviewResponse(
             start_date=start_date,
@@ -582,6 +626,12 @@ class SessionService:
             total_cjk_chars=total_cjk_chars,
             total_latin_chars=total_latin_chars,
             total_other_chars=total_other_chars,
+            yield_ratio_tokens_mean=mean(token_yield_ratios) if token_yield_ratios else 0.0,
+            yield_ratio_tokens_median=median(token_yield_ratios) if token_yield_ratios else 0.0,
+            yield_ratio_tokens_p90=token_p90,
+            yield_ratio_chars_mean=mean(char_yield_ratios) if char_yield_ratios else 0.0,
+            yield_ratio_chars_median=median(char_yield_ratios) if char_yield_ratios else 0.0,
+            yield_ratio_chars_p90=chars_p90,
             avg_automation_ratio=mean(automation_values) if automation_values else 0.0,
             avg_session_duration_seconds=mean(duration_values) if duration_values else 0.0,
             model_time_seconds=model_time_seconds,

--- a/claude_vis/models.py
+++ b/claude_vis/models.py
@@ -394,6 +394,8 @@ class SessionStatistics(BaseModel):
     cache_creation_tokens: int = 0
     trajectory_file_size_bytes: int = 0
     character_breakdown: CharacterBreakdown = Field(default_factory=CharacterBreakdown)
+    user_yield_ratio_tokens: float | None = None
+    user_yield_ratio_chars: float | None = None
 
     # Tool statistics
     tool_calls: list[ToolCallStatistics] = Field(default_factory=list)

--- a/claude_vis/parsers/claude_code.py
+++ b/claude_vis/parsers/claude_code.py
@@ -822,6 +822,15 @@ def calculate_session_statistics(
             command_stats=sorted_cmds,
         )
 
+    tool_token_total = sum(int(tool_stats[name]["tokens"]) for name in tool_stats)
+    user_yield_ratio_tokens = None
+    if total_input_tokens > 0:
+        user_yield_ratio_tokens = (total_output_tokens + tool_token_total) / total_input_tokens
+
+    user_yield_ratio_chars = None
+    if user_chars > 0:
+        user_yield_ratio_chars = (model_chars + tool_chars) / user_chars
+
     return SessionStatistics(
         message_count=len(messages),
         user_message_count=user_count,
@@ -844,6 +853,8 @@ def calculate_session_statistics(
             whitespace_chars=whitespace_chars,
             other_chars=other_chars,
         ),
+        user_yield_ratio_tokens=user_yield_ratio_tokens,
+        user_yield_ratio_chars=user_yield_ratio_chars,
         tool_calls=tool_call_list,
         tool_groups=tool_group_list,
         total_tool_calls=sum(int(tool_stats[t]["count"]) for t in tool_stats),

--- a/frontend/src/components/CrossSessionOverview.tsx
+++ b/frontend/src/components/CrossSessionOverview.tsx
@@ -232,6 +232,20 @@ export function CrossSessionOverview() {
           <h4>Automation efficiency</h4>
           <div className="kpi-value">{overview.avg_automation_ratio.toFixed(2)}x</div>
           <p>Active ratio: {formatPercent(overview.active_time_ratio * 100)}</p>
+          <p>
+            Token yield (mean/median/p90): {overview.yield_ratio_tokens_mean.toFixed(2)}x /
+            {' '}
+            {overview.yield_ratio_tokens_median.toFixed(2)}x /
+            {' '}
+            {overview.yield_ratio_tokens_p90.toFixed(2)}x
+          </p>
+          <p>
+            Char yield (mean/median/p90): {overview.yield_ratio_chars_mean.toFixed(2)}x /
+            {' '}
+            {overview.yield_ratio_chars_median.toFixed(2)}x /
+            {' '}
+            {overview.yield_ratio_chars_p90.toFixed(2)}x
+          </p>
         </article>
 
         <article className="kpi-card">

--- a/frontend/src/components/StatisticsDashboard.tsx
+++ b/frontend/src/components/StatisticsDashboard.tsx
@@ -155,6 +155,12 @@ export function StatisticsDashboard({ sessionId }: StatisticsDashboardProps) {
   const automationRatio = interactions > 0
     ? statistics.total_tool_calls / interactions
     : null;
+  const tokenYieldRatio = typeof statistics.user_yield_ratio_tokens === 'number'
+    ? statistics.user_yield_ratio_tokens
+    : null;
+  const charYieldRatio = typeof statistics.user_yield_ratio_chars === 'number'
+    ? statistics.user_yield_ratio_chars
+    : null;
 
   const withCalls = statistics.tool_calls.filter((item) => item.count > 0);
   const weightedLatency = withCalls.reduce(
@@ -257,6 +263,21 @@ export function StatisticsDashboard({ sessionId }: StatisticsDashboardProps) {
               <div className="breakdown-item">
                 <span className="breakdown-label">Agent types</span>
                 <span className="breakdown-value">{Object.keys(statistics.subagent_sessions).length}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="stat-card">
+            <h4 className="card-title">User Yield Ratio</h4>
+            <div className="stat-value large">
+              {tokenYieldRatio !== null ? `${tokenYieldRatio.toFixed(2)}x` : 'N/A'}
+            </div>
+            <div className="stat-breakdown">
+              <div className="breakdown-item">
+                <span className="breakdown-label">Chars output/input</span>
+                <span className="breakdown-value">
+                  {charYieldRatio !== null ? `${charYieldRatio.toFixed(2)}x` : 'N/A'}
+                </span>
               </div>
             </div>
           </div>

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -291,6 +291,8 @@ export interface SessionStatistics {
   cache_creation_tokens: number;
   trajectory_file_size_bytes: number;
   character_breakdown: CharacterBreakdown;
+  user_yield_ratio_tokens: number | null;
+  user_yield_ratio_chars: number | null;
   tool_calls: ToolCallStatistics[];
   tool_groups: ToolGroupStatistics[];
   total_tool_calls: number;
@@ -360,6 +362,12 @@ export interface AnalyticsOverviewResponse {
   total_cjk_chars: number;
   total_latin_chars: number;
   total_other_chars: number;
+  yield_ratio_tokens_mean: number;
+  yield_ratio_tokens_median: number;
+  yield_ratio_tokens_p90: number;
+  yield_ratio_chars_mean: number;
+  yield_ratio_chars_median: number;
+  yield_ratio_chars_p90: number;
   avg_automation_ratio: number;
   avg_session_duration_seconds: number;
   model_time_seconds: number;

--- a/frontend/tests/cross-session-char-metrics.spec.ts
+++ b/frontend/tests/cross-session-char-metrics.spec.ts
@@ -32,6 +32,12 @@ test.describe('@full Cross Session Char Metrics', () => {
           total_cjk_chars: 90000,
           total_latin_chars: 330000,
           total_other_chars: 30000,
+          yield_ratio_tokens_mean: 2.4,
+          yield_ratio_tokens_median: 2.2,
+          yield_ratio_tokens_p90: 3.1,
+          yield_ratio_chars_mean: 3.5,
+          yield_ratio_chars_median: 3.3,
+          yield_ratio_chars_p90: 4.2,
           avg_automation_ratio: 2.5,
           avg_session_duration_seconds: 4200,
           model_time_seconds: 36000,
@@ -106,6 +112,12 @@ test.describe('@full Cross Session Char Metrics', () => {
     );
     await expect(page.locator('.kpi-card', { hasText: 'Token volume' })).toContainText(
       'Chars (CJK/Latin): 90,000 / 330,000'
+    );
+    await expect(page.locator('.kpi-card', { hasText: 'Automation efficiency' })).toContainText(
+      'Token yield (mean/median/p90): 2.40x / 2.20x / 3.10x'
+    );
+    await expect(page.locator('.kpi-card', { hasText: 'Automation efficiency' })).toContainText(
+      'Char yield (mean/median/p90): 3.50x / 3.30x / 4.20x'
     );
   });
 });

--- a/frontend/tests/fixtures/mockData.ts
+++ b/frontend/tests/fixtures/mockData.ts
@@ -192,6 +192,8 @@ export const mockSessionStatistics: SessionStatisticsResponse = {
       whitespace_chars: 1200,
       other_chars: 200,
     },
+    user_yield_ratio_tokens: 1.9,
+    user_yield_ratio_chars: 3.0,
     tool_calls: [
       {
         tool_name: 'Read',

--- a/frontend/tests/statistics-dashboard.spec.ts
+++ b/frontend/tests/statistics-dashboard.spec.ts
@@ -59,6 +59,7 @@ test.describe('@smoke Statistics Dashboard - Tool Errors', () => {
     await openStatisticsTab(page);
     await expect(page.locator('.dashboard-title')).toHaveText('Session Metrics');
     await expect(page.locator('.card-title', { hasText: 'Tool Error Timeline' })).toBeVisible();
+    await expect(page.locator('.card-title', { hasText: 'User Yield Ratio' })).toBeVisible();
     await expect(page.locator('.card-title', { hasText: 'Trajectory Size' })).toBeVisible();
     await expect(page.locator('.card-title', { hasText: 'Character Volume' })).toBeVisible();
 

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -245,6 +245,8 @@ class TestSessionStatisticsAPI:
             assert "total_output_tokens" in stats
             assert "trajectory_file_size_bytes" in stats
             assert "character_breakdown" in stats
+            assert "user_yield_ratio_tokens" in stats
+            assert "user_yield_ratio_chars" in stats
 
     def test_statistics_tool_call_data(self, test_client: TestClient) -> None:
         """Test that statistics include tool call information."""
@@ -293,6 +295,12 @@ class TestAnalyticsAPI:
         assert "active_time_ratio" in payload
         assert "total_trajectory_file_size_bytes" in payload
         assert "total_chars" in payload
+        assert "yield_ratio_tokens_mean" in payload
+        assert "yield_ratio_tokens_median" in payload
+        assert "yield_ratio_tokens_p90" in payload
+        assert "yield_ratio_chars_mean" in payload
+        assert "yield_ratio_chars_median" in payload
+        assert "yield_ratio_chars_p90" in payload
 
         start = date.fromisoformat(payload["start_date"])
         end = date.fromisoformat(payload["end_date"])
@@ -312,6 +320,8 @@ class TestAnalyticsAPI:
         assert payload["total_messages"] >= 1
         assert payload["total_tokens"] >= 1
         assert 0.0 <= payload["active_time_ratio"] <= 1.0
+        assert payload["yield_ratio_tokens_p90"] >= payload["yield_ratio_tokens_median"]
+        assert payload["yield_ratio_chars_p90"] >= payload["yield_ratio_chars_median"]
 
         active = (
             payload["model_time_seconds"]

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -344,6 +344,22 @@ class TestCalculateSessionStatistics:
         assert edit_tool is not None
         assert edit_tool.total_tokens == 180
 
+    def test_user_yield_ratios(
+        self, temp_session_dir: Path, sample_messages_with_tools: list[dict[str, object]]
+    ) -> None:
+        """Token/character yield ratios should be computed with available denominators."""
+        file_path = temp_session_dir / "test-yield.jsonl"
+        with open(file_path, "w", encoding="utf-8") as f:
+            for data in sample_messages_with_tools:
+                f.write(json.dumps(data) + "\n")
+
+        messages = parse_jsonl_file(file_path)
+        stats = calculate_session_statistics(messages)
+
+        assert stats.user_yield_ratio_tokens == pytest.approx(2.0, abs=1e-6)
+        assert stats.user_yield_ratio_chars is not None
+        assert stats.user_yield_ratio_chars > 0
+
     def test_tool_error_records_are_categorized(
         self, temp_session_dir: Path, sample_messages_with_tools: list[dict[str, object]]
     ) -> None:
@@ -418,6 +434,31 @@ class TestCalculateSessionStatistics:
         assert stats.tool_error_records[0].category == UNCATEGORIZED_ERROR
         assert stats.tool_error_records[0].matched_rule is None
         assert stats.tool_error_category_counts == {UNCATEGORIZED_ERROR: 1}
+
+    def test_user_yield_ratio_zero_denominator(self, temp_session_dir: Path) -> None:
+        """Yield ratios should be None when denominator inputs are absent."""
+        file_path = temp_session_dir / "yield-zero.jsonl"
+        messages = [
+            {
+                "type": "assistant",
+                "sessionId": "yield-zero",
+                "uuid": "msg-1",
+                "timestamp": "2026-02-03T13:15:17.231Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "output only"}],
+                    "usage": {"input_tokens": 0, "output_tokens": 20},
+                },
+            }
+        ]
+        with open(file_path, "w", encoding="utf-8") as f:
+            for data in messages:
+                f.write(json.dumps(data) + "\n")
+
+        parsed = parse_jsonl_file(file_path)
+        stats = calculate_session_statistics(parsed)
+        assert stats.user_yield_ratio_tokens is None
+        assert stats.user_yield_ratio_chars is None
 
     def test_session_duration(
         self, temp_session_dir: Path, sample_messages_with_tools: list[dict[str, object]]


### PR DESCRIPTION
## Summary
- add per-session user yield ratios for tokens and characters (`user_yield_ratio_tokens`, `user_yield_ratio_chars`) with zero-denominator safeguards
- aggregate token/char yield ratios in analytics overview with mean/median/p90 fields
- expose yield metrics in single-session automation cards and cross-session overview panels
- extend integration/unit tests and E2E assertions for ratio math and API/UI contract coverage

## Validation
- uv run ruff check claude_vis/models.py claude_vis/parsers/claude_code.py claude_vis/api/models.py claude_vis/api/service.py tests/test_statistics.py tests/test_api_integration.py --ignore E501
- uv run pytest tests/test_statistics.py tests/test_api_integration.py tests/test_character_metrics.py -q
- npm --prefix frontend run lint -- src/components/StatisticsDashboard.tsx src/components/CrossSessionOverview.tsx tests/statistics-dashboard.spec.ts tests/cross-session-char-metrics.spec.ts
- npm --prefix frontend run type-check
- npm --prefix frontend run test:e2e -- tests/statistics-dashboard.spec.ts tests/cross-session-char-metrics.spec.ts --project=chromium
